### PR TITLE
Migrating responsibilities of the binding descriptors API's to `vk::command_buffer`

### DIFF
--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -671,9 +671,10 @@ main() {
         // std::array<VkBuffer, 1> vertex = { test_model.vertex_handle() };
         const VkBuffer vertex = test_model.vertex_handle();
         uint64_t offset = 0;
-        current.bind_vertex_buffers(std::span<const VkBuffer>(&vertex, 1), std::span<uint64_t>(&offset, 1));
+        current.bind_vertex_buffers(std::span<const VkBuffer>(&vertex, 1),
+                                    std::span<uint64_t>(&offset, 1));
 
-        if(test_model.has_indices()) {
+        if (test_model.has_indices()) {
             current.bind_index_buffers32(test_model.index_handle());
         }
 

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -168,13 +168,13 @@ public:
 
     [[nodiscard]] bool loaded() const { return m_is_loaded; }
 
-    void bind(const VkCommandBuffer& p_command) {
-        m_vertex_buffer.bind(p_command);
+    [[nodiscard]] VkBuffer vertex_handle() const { return m_vertex_buffer; }
 
-        if (m_has_indices) {
-            m_index_buffer.bind(p_command);
-        }
-    }
+    [[nodiscard]] VkBuffer index_handle() const { return m_index_buffer; }
+
+    [[nodiscard]] bool has_indices() const { return m_has_indices; }
+
+    [[nodiscard]] uint32_t indices_size() const { return m_indices_size; }
 
     void draw(const VkCommandBuffer& p_command) {
         if (m_has_indices) {
@@ -667,8 +667,15 @@ main() {
         // drawing stuff to
         main_graphics_pipeline.bind(current);
 
-        // Must be binded before descriptor resource gets binded
-        test_model.bind(current);
+        // test_model.bind(current);
+        // std::array<VkBuffer, 1> vertex = { test_model.vertex_handle() };
+        const VkBuffer vertex = test_model.vertex_handle();
+        uint64_t offset = 0;
+        current.bind_vertex_buffers(std::span<const VkBuffer>(&vertex, 1), std::span<uint64_t>(&offset, 1));
+
+        if(test_model.has_indices()) {
+            current.bind_index_buffers32(test_model.index_handle());
+        }
 
         static auto start_time = std::chrono::high_resolution_clock::now();
 
@@ -703,8 +710,10 @@ main() {
         // buffers or else that becomes undefined behavior
         // set0_resource.bind(current, main_graphics_pipeline.layout());
 
-        std::array<const VkDescriptorSet, 2> descriptors = { set0_resource,
-                                                             set1_resource };
+        std::array<const VkDescriptorSet, 2> descriptors = {
+            set0_resource,
+            set1_resource,
+        };
 
         current.bind_descriptors(main_graphics_pipeline.layout(),
                                  VK_PIPELINE_BIND_POINT_GRAPHICS,

--- a/demos/13-skybox/environment_map.cppm
+++ b/demos/13-skybox/environment_map.cppm
@@ -543,9 +543,10 @@ public:
         m_skybox_ubo.transfer(std::span<const skybox_uniform>(&p_ubo, 1));
     }
 
-    void bind(const VkCommandBuffer& p_current) {
+    void bind(vk::command_buffer p_current) {
         m_skybox_pipeline.bind(p_current);
-        m_skybox_descriptors.bind(p_current, m_skybox_pipeline.layout());
+        std::array<VkDescriptorSet, 1> descriptors = { m_skybox_descriptors };
+        p_current.bind_descriptors(m_skybox_pipeline.layout(), VK_PIPELINE_BIND_POINT_GRAPHICS, descriptors);
         m_skybox_vbo.bind(p_current);
     }
 

--- a/demos/13-skybox/environment_map.cppm
+++ b/demos/13-skybox/environment_map.cppm
@@ -546,7 +546,9 @@ public:
     void bind(vk::command_buffer p_current) {
         m_skybox_pipeline.bind(p_current);
         std::array<VkDescriptorSet, 1> descriptors = { m_skybox_descriptors };
-        p_current.bind_descriptors(m_skybox_pipeline.layout(), VK_PIPELINE_BIND_POINT_GRAPHICS, descriptors);
+        p_current.bind_descriptors(m_skybox_pipeline.layout(),
+                                   VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                   descriptors);
         m_skybox_vbo.bind(p_current);
     }
 

--- a/demos/14-imgui/CMakeLists.txt
+++ b/demos/14-imgui/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.27)
+project(model-loading CXX)
+
+build_application(
+    SOURCES
+    application.cpp
+
+    PACKAGES
+    vulkan-cpp
+    Vulkan
+    glfw3
+    glm
+    stb
+    tinyobjloader
+
+    LINK_PACKAGES
+    vulkan-cpp
+    tinyobjloader
+    Vulkan::Vulkan
+)

--- a/demos/14-imgui/application.cpp
+++ b/demos/14-imgui/application.cpp
@@ -1,0 +1,764 @@
+#define GLFW_INCLUDE_VULKAN
+#if _WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#include <GLFW/glfw3.h>
+#define GLFW_EXPOSE_NATIVE_WIN32
+#include <GLFW/glfw3native.h>
+#include <vulkan/vulkan.h>
+#else
+#include <GLFW/glfw3.h>
+#include <vulkan/vulkan.h>
+#endif
+
+#include <array>
+#include <print>
+#include <span>
+#include <filesystem>
+import vk;
+
+#include <chrono>
+#define GLM_FORCE_RADIANS
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
+
+#include <stdio.h>
+
+#include <tiny_obj_loader.h>
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL
+debug_callback(
+  [[maybe_unused]] VkDebugUtilsMessageSeverityFlagBitsEXT p_message_severity,
+  [[maybe_unused]] VkDebugUtilsMessageTypeFlagsEXT p_message_type,
+  const VkDebugUtilsMessengerCallbackDataEXT* p_callback_data,
+  [[maybe_unused]] void* p_user_data) {
+    std::print("validation layer:\t\t{}\n\n", p_callback_data->pMessage);
+    return false;
+}
+
+struct global_uniform {
+    glm::mat4 model;
+    glm::mat4 view;
+    glm::mat4 proj;
+};
+
+template<typename T, typename... Rest>
+void
+hash_combine(size_t& seed, const T& v, const Rest&... rest) {
+    seed ^= std::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed << 2);
+    (hash_combine(seed, rest), ...);
+}
+
+namespace std {
+
+    template<>
+    struct hash<vk::vertex_input> {
+        size_t operator()(const vk::vertex_input& vertex) const {
+            size_t seed = 0;
+            hash_combine(
+              seed, vertex.position, vertex.color, vertex.normals, vertex.uv);
+            return seed;
+        }
+    };
+}
+
+// Part of this demo for loading a 3D .obj model
+class obj_model {
+public:
+    obj_model() = default;
+    obj_model(const std::filesystem::path& p_filename,
+              const VkDevice& p_device,
+              const vk::physical_device& p_physical) {
+        tinyobj::attrib_t attrib;
+        std::vector<tinyobj::shape_t> shapes;
+        std::vector<tinyobj::material_t> materials;
+        std::string warn, err;
+
+        //! @note If we return the constructor then we can check if the mesh
+        //! loaded successfully
+        //! @note We also receive hints if the loading is successful!
+        //! @note Return default constructor automatically returns false means
+        //! that mesh will return the boolean as false because it wasnt
+        //! successful
+        if (!tinyobj::LoadObj(&attrib,
+                              &shapes,
+                              &materials,
+                              &warn,
+                              &err,
+                              p_filename.string().c_str())) {
+            std::println("Could not load model from path {}",
+                         p_filename.string());
+            m_is_loaded = false;
+            return;
+        }
+
+        std::vector<vk::vertex_input> vertices;
+        std::vector<uint32_t> indices;
+        std::unordered_map<vk::vertex_input, uint32_t> unique_vertices{};
+
+        for (const auto& shape : shapes) {
+            for (const auto& index : shape.mesh.indices) {
+                vk::vertex_input vertex{};
+
+                // vertices.push_back(vertex);
+                if (!unique_vertices.contains(vertex)) {
+                    unique_vertices[vertex] =
+                      static_cast<uint32_t>(vertices.size());
+                    vertices.push_back(vertex);
+                }
+
+                if (index.vertex_index >= 0) {
+                    vertex.position = {
+                        attrib.vertices[3 * index.vertex_index + 0],
+                        attrib.vertices[3 * index.vertex_index + 1],
+                        attrib.vertices[3 * index.vertex_index + 2]
+                    };
+
+                    vertex.color = {
+                        attrib.colors[3 * index.vertex_index + 0],
+                        attrib.colors[3 * index.vertex_index + 1],
+                        attrib.colors[3 * index.vertex_index + 2]
+                    };
+                }
+
+                if (index.normal_index >= 0) {
+                    vertex.normals = {
+                        attrib.normals[3 * index.normal_index + 0],
+                        attrib.normals[3 * index.normal_index + 1],
+                        attrib.normals[3 * index.normal_index + 2]
+                    };
+                }
+
+                if (index.texcoord_index >= 0) {
+                    vertex.uv = {
+                        attrib.texcoords[2 * index.texcoord_index + 0],
+                        1.0f - attrib.texcoords[2 * index.texcoord_index + 1]
+                    };
+                }
+
+                if (!unique_vertices.contains(vertex)) {
+                    unique_vertices[vertex] =
+                      static_cast<uint32_t>(vertices.size());
+                    vertices.push_back(vertex);
+                }
+
+                indices.push_back(unique_vertices[vertex]);
+            }
+        }
+
+        m_has_indices = (indices.size() > 0) ? true : false;
+
+        if (m_has_indices) {
+            m_indices_size = indices.size();
+        }
+        m_indices_size = vertices.size();
+        m_indices_size = indices.size();
+        vk::vertex_params vertex_info = {
+            .phsyical_memory_properties = p_physical.memory_properties(),
+        };
+
+        vk::index_params index_info = { .phsyical_memory_properties =
+                                          p_physical.memory_properties() };
+
+        m_vertex_buffer = vk::vertex_buffer(p_device, vertices, vertex_info);
+        m_index_buffer = vk::index_buffer(p_device, indices, index_info);
+        m_is_loaded = true;
+    }
+
+    [[nodiscard]] bool loaded() const { return m_is_loaded; }
+
+    void bind(const VkCommandBuffer& p_command) {
+        m_vertex_buffer.bind(p_command);
+
+        if (m_has_indices) {
+            m_index_buffer.bind(p_command);
+        }
+    }
+
+    void draw(const VkCommandBuffer& p_command) {
+        if (m_has_indices) {
+            vkCmdDrawIndexed(p_command, m_indices_size, 1, 0, 0, 0);
+        }
+        else {
+            vkCmdDraw(p_command, m_indices_size, 1, 0, 0);
+        }
+    }
+
+    void destroy() {
+        m_vertex_buffer.destroy();
+        m_index_buffer.destroy();
+    }
+
+private:
+    bool m_is_loaded = false;
+    bool m_has_indices = false;
+    uint32_t m_indices_size = 0;
+    vk::vertex_buffer m_vertex_buffer{};
+    vk::index_buffer m_index_buffer{};
+};
+
+std::vector<const char*>
+get_instance_extensions() {
+    std::vector<const char*> extension_names;
+    uint32_t extension_count = 0;
+    const char** required_extensions =
+      glfwGetRequiredInstanceExtensions(&extension_count);
+
+    for (uint32_t i = 0; i < extension_count; i++) {
+        std::println("Required Extension = {}", required_extensions[i]);
+        extension_names.emplace_back(required_extensions[i]);
+    }
+
+    extension_names.emplace_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+#if defined(__APPLE__)
+    extension_names.emplace_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+    extension_names.emplace_back(
+      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+#endif
+
+    return extension_names;
+}
+
+int
+main() {
+    //! @note Just added the some test code to test the conan-starter setup code
+    if (!glfwInit()) {
+        std::println("glfwInit could not be initialized!");
+        return -1;
+    }
+
+    if (!glfwVulkanSupported()) {
+        std::println("GLFW: Vulkan is not supported!");
+        return -1;
+    }
+
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+
+    int width = 800;
+    int height = 600;
+    std::string title = "Hello Window";
+    GLFWwindow* window =
+      glfwCreateWindow(width, height, title.c_str(), nullptr, nullptr);
+
+    glfwMakeContextCurrent(window);
+
+    std::array<const char*, 1> validation_layers = {
+        "VK_LAYER_KHRONOS_validation",
+    };
+
+    // setting up extensions
+    std::vector<const char*> global_extensions = get_instance_extensions();
+
+    vk::debug_message_utility debug_callback_info = {
+        .severity =
+          vk::message::verbose | vk::message::warning | vk::message::error,
+        .message_type =
+          vk::debug::general | vk::debug::validation | vk::debug::performance,
+        .callback = debug_callback
+    };
+
+    vk::application_params config = {
+        .name = "vulkan instance",
+        .version = vk::api_version::vk_1_3, // specify to using vulkan 1.3
+        .validations =
+          validation_layers, // .validation takes in a std::span<const char*>
+        .extensions =
+          global_extensions // .extensions also takes in std::span<const char*>
+    };
+
+    // Setting up vk instance
+    vk::instance api_instance(config, debug_callback_info);
+
+    if (api_instance.alive()) {
+        std::println("\napi_instance alive and initiated!!!");
+    }
+
+    vk::physical_enumeration enumerate_devices{
+        .device_type = vk::physical_gpu::discrete,
+    };
+
+    // Specifically set for the mac m1 series platform
+#if defined(__APPLE__)
+    enumerate_devices.device_type = vk::physical_gpu::integrated;
+#endif
+
+    vk::physical_device physical_device(api_instance, enumerate_devices);
+
+    // selecting depth format
+    std::array<vk::format, 3> format_support = {
+        vk::format::d32_sfloat,
+        vk::format::d32_sfloat_s8_uint,
+        vk::format::d24_unorm_s8_uint
+    };
+
+    // We provide a selection of format support that we want to check is
+    // supported on current hardware device.
+    VkFormat depth_format =
+      vk::select_depth_format(physical_device, format_support);
+
+    vk::queue_indices queue_indices = physical_device.family_indices();
+    std::println("Graphics Queue Family Index = {}", queue_indices.graphics);
+    std::println("Compute Queue Family Index = {}", queue_indices.compute);
+    std::println("Transfer Queue Family Index = {}", queue_indices.transfer);
+
+    // setting up logical device
+    std::array<float, 1> priorities = { 0.f };
+
+#if defined(__APPLE__)
+    std::array<const char*, 2> extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                                              "VK_KHR_portability_subset" };
+#else
+    std::array<const char*, 1> extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+#endif
+
+    vk::device_params logical_device_params = {
+        .queue_priorities = priorities,
+        .extensions = extensions,
+        .queue_family_index = 0,
+    };
+
+    vk::device logical_device(physical_device, logical_device_params);
+
+    vk::surface window_surface(api_instance, window);
+    std::println("Starting implementation of the swapchain!!!");
+
+    vk::surface_params surface_properties =
+      vk::enumerate_surface(physical_device, window_surface);
+
+    if (surface_properties.format.format != VK_FORMAT_UNDEFINED) {
+        std::println("Surface Format.format is not undefined!!!");
+    }
+
+    vk::swapchain_params enumerate_swapchain_settings = {
+        .width = (uint32_t)width,
+        .height = (uint32_t)height,
+        .present_index =
+          physical_device.family_indices()
+            .graphics, // presentation index just uses the graphics index
+    };
+    vk::swapchain main_swapchain(logical_device,
+                                 window_surface,
+                                 enumerate_swapchain_settings,
+                                 surface_properties);
+
+    // querying swapchain images
+    std::span<const VkImage> images = main_swapchain.get_images();
+    uint32_t image_count = static_cast<uint32_t>(images.size());
+
+    // Creating Images
+    std::vector<vk::sample_image> swapchain_images(image_count);
+    std::vector<vk::sample_image> swapchain_depth_images(image_count);
+
+    VkExtent2D swapchain_extent = surface_properties.capabilities.currentExtent;
+
+    // Setting up the images
+    uint32_t layer_count = 1;
+    uint32_t mip_levels = 1;
+    for (uint32_t i = 0; i < swapchain_images.size(); i++) {
+        vk::image_params swapchain_image_config = {
+            .extent = { .width = swapchain_extent.width,
+                        .height = swapchain_extent.height },
+            .format = surface_properties.format.format,
+            .aspect = vk::image_aspect_flags::color_bit,
+            .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+            .mip_levels = 1,
+            .layer_count = 1,
+            .phsyical_memory_properties = physical_device.memory_properties(),
+        };
+
+        swapchain_images[i] =
+          vk::sample_image(logical_device, images[i], swapchain_image_config);
+
+        // Creating Images for depth buffering
+        vk::image_params image_config = {
+            .extent = { .width = swapchain_extent.width,
+                        .height = swapchain_extent.height },
+            .format = depth_format,
+            .aspect = vk::image_aspect_flags::depth_bit,
+            .usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+            .mip_levels = 1,
+            .layer_count = 1,
+            .phsyical_memory_properties = physical_device.memory_properties(),
+        };
+        swapchain_depth_images[i] =
+          vk::sample_image(logical_device, image_config);
+    }
+
+    // setting up command buffers
+    std::vector<vk::command_buffer> swapchain_command_buffers(image_count);
+    for (size_t i = 0; i < swapchain_command_buffers.size(); i++) {
+        vk::command_params settings = {
+            .levels = vk::command_levels::primary,
+            .queue_index = enumerate_swapchain_settings.present_index,
+            .flags = vk::command_pool_flags::reset,
+        };
+
+        swapchain_command_buffers[i] =
+          vk::command_buffer(logical_device, settings);
+    }
+
+    // setting up attachments for the renderpass
+    std::array<vk::attachment, 2> renderpass_attachments = {
+        // color attachment
+        vk::attachment{
+          .format = surface_properties.format.format,
+          .layout = vk::image_layout::color_optimal,
+          .samples = vk::sample_bit::count_1,
+          .load = vk::attachment_load::clear,
+          .store = vk::attachment_store::store,
+          .stencil_load = vk::attachment_load::dont_care,
+          .stencil_store = vk::attachment_store::dont_care,
+          .initial_layout = vk::image_layout::undefined,
+          .final_layout = vk::image_layout::present_src_khr,
+        },
+        // depth attachment
+        vk::attachment{
+          .format = depth_format,
+          .layout = vk::image_layout::depth_stencil_optimal,
+          .samples = vk::sample_bit::count_1,
+          .load = vk::attachment_load::clear,
+          .store = vk::attachment_store::dont_care,
+          .stencil_load = vk::attachment_load::dont_care,
+          .stencil_store = vk::attachment_store::dont_care,
+          .initial_layout = vk::image_layout::undefined,
+          .final_layout = vk::image_layout::depth_stencil_read_only_optimal,
+        },
+    };
+
+    vk::renderpass main_renderpass(logical_device, renderpass_attachments);
+
+    std::println("renderpass created!!!");
+
+    // Setting up swapchain framebuffers
+
+    std::vector<vk::framebuffer> swapchain_framebuffers(image_count);
+    for (uint32_t i = 0; i < swapchain_framebuffers.size(); i++) {
+
+        // NOTE: This must match the amount of attachments the renderpass also
+        // has to match the image_view attachment for per-framebuffers as well
+        // I just set the size to whatever the renderpass attachment size are to
+        // ensure this is the case Since you have an image for color attachment
+        // and another image for the depth atttachment to specify
+        std::array<VkImageView, renderpass_attachments.size()>
+          image_view_attachments = { swapchain_images[i].image_view(),
+                                     swapchain_depth_images[i].image_view() };
+
+        vk::framebuffer_params framebuffer_info = {
+            .renderpass = main_renderpass,
+            .views = image_view_attachments,
+            .extent = swapchain_extent
+        };
+        swapchain_framebuffers[i] =
+          vk::framebuffer(logical_device, framebuffer_info);
+    }
+
+    std::println("Created VkFramebuffer's with size = {}",
+                 swapchain_framebuffers.size());
+
+    // setting up presentation queue to display commands to the screen
+    vk::queue_params enumerate_present_queue{
+        .family = 0,
+        .index = 0,
+    };
+    vk::device_present_queue presentation_queue(
+      logical_device, main_swapchain, enumerate_present_queue);
+
+    // gets set with the renderpass
+    std::array<float, 4> color = { 0.f, 0.5f, 0.5f, 1.f };
+
+    // std::println("Start implementing graphics pipeline!!!");
+
+    // Now creating a vulkan graphics pipeline for the shader loading
+    std::array<vk::shader_source, 2> shader_sources = {
+        vk::shader_source{
+          .filename = "shader_samples/sample5/test.vert.spv",
+          .stage = vk::shader_stage::vertex,
+        },
+        vk::shader_source{
+          .filename = "shader_samples/sample5/test.frag.spv",
+          .stage = vk::shader_stage::fragment,
+        },
+    };
+
+    // Setting up vertex attributes in the test shaders
+    std::array<vk::vertex_attribute_entry, 4> attribute_entries = {
+        vk::vertex_attribute_entry{
+          .location = 0,
+          .format = vk::format::rgb32_sfloat,
+          .stride = offsetof(vk::vertex_input, position),
+        },
+        vk::vertex_attribute_entry{
+          .location = 1,
+          .format = vk::format::rgb32_sfloat,
+          .stride = offsetof(vk::vertex_input, color),
+        },
+        vk::vertex_attribute_entry{
+          .location = 2,
+          .format = vk::format::rg32_sfloat,
+          .stride = offsetof(vk::vertex_input, uv),
+        },
+        vk::vertex_attribute_entry{
+          .location = 3,
+          .format = vk::format::rgb32_sfloat,
+          .stride = offsetof(vk::vertex_input, normals),
+        }
+    };
+
+    std::array<vk::vertex_attribute, 1> attributes = {
+        vk::vertex_attribute{
+          // layout (set = 0, binding = 0)
+          .binding = 0,
+          .entries = attribute_entries,
+          .stride = sizeof(vk::vertex_input),
+          .input_rate = vk::input_rate::vertex,
+        },
+    };
+
+    // To render triangle, we do not need to set any vertex attributes
+    vk::shader_resource_info shader_info = {
+        .sources = shader_sources,
+        .vertex_attributes =
+          attributes // NOT NEEDED: Specifying vertex attributes
+    };
+    vk::shader_resource geometry_resource(logical_device, shader_info);
+    geometry_resource.vertex_attributes(attributes);
+
+    // Set 0: For Uniform BUffers (or global scene data)
+    std::vector<vk::descriptor_entry> entries = {
+    vk::descriptor_entry{
+            // specifies "layout (set = 0, binding = 0) uniform GlobalUbo"
+            .type = vk::buffer::uniform,
+            .binding_point = {
+                .binding = 0,
+                .stage = vk::shader_stage::vertex,
+            },
+            .descriptor_count = 1,
+        },
+    };
+    vk::descriptor_layout set0_layout = {
+        .slot = 0,               // indicate specific descriptor slot 0
+        .max_sets = image_count, // max descriptors to allocate
+        .entries = entries,      // descriptor layout entries description
+    };
+    vk::descriptor_resource set0_resource(logical_device, set0_layout);
+
+    // Set 1 = For Textures
+    std::vector<vk::descriptor_entry> entries_set1 = {
+        vk::descriptor_entry{
+            // layout (set = 1, binding = 0) uniform sampler2D
+            .type = vk::buffer::combined_image_sampler,
+            .binding_point = {
+                .binding = 0,
+                .stage = vk::shader_stage::fragment,
+            },
+            .descriptor_count = 1,
+        }
+    };
+    vk::descriptor_layout set1_layout = {
+        .slot = 1,               // indicate specific descriptor slot 0
+        .max_sets = image_count, // max descriptors to allocate
+        .entries = entries_set1, // descriptor layout entries description
+    };
+
+    vk::descriptor_resource set1_resource(logical_device, set1_layout);
+
+    std::array<VkDescriptorSetLayout, 2> layouts = {
+        set0_resource.layout(),
+        set1_resource.layout(),
+    };
+
+    std::array<vk::color_blend_attachment_state, 1> color_blend_attachments = {
+        vk::color_blend_attachment_state{},
+    };
+
+    std::array<vk::dynamic_state, 2> dynamic_states = {
+        vk::dynamic_state::viewport, vk::dynamic_state::scissor
+    };
+    vk::pipeline_params pipeline_configuration = {
+        .renderpass = main_renderpass,
+        .shader_modules = geometry_resource.handles(),
+        .vertex_attributes = geometry_resource.vertex_attributes(),
+        .vertex_bind_attributes = geometry_resource.vertex_bind_attributes(),
+        .descriptor_layouts = layouts,
+        .color_blend = {
+            .attachments = color_blend_attachments,
+        },
+        .depth_stencil_enabled = true,
+        .dynamic_states = dynamic_states,
+    };
+    vk::pipeline main_graphics_pipeline(logical_device, pipeline_configuration);
+
+    // Loading mesh
+    obj_model test_model(std::filesystem::path("asset_samples/viking_room.obj"),
+                         logical_device,
+                         physical_device);
+
+    // Setting up descriptor sets for handling uniforms
+    vk::uniform_params test_ubo_info = {
+        .phsyical_memory_properties = physical_device.memory_properties()
+    };
+    vk::uniform_buffer test_ubo =
+      vk::uniform_buffer(logical_device, sizeof(global_uniform), test_ubo_info);
+    // std::println("uniform_buffer.alive() = {}", test_ubo.alive());
+
+    std::array<vk::write_buffer, 1> uniforms0 = {
+        vk::write_buffer{
+          .buffer = test_ubo,
+          .offset = 0,
+          .range = static_cast<uint32_t>(test_ubo.size_bytes()),
+        },
+    };
+    std::array<vk::write_buffer_descriptor, 1> uniforms = {
+        vk::write_buffer_descriptor{
+          .dst_binding = 0,
+          .uniforms = uniforms0,
+        },
+    };
+
+    // Loading a texture
+    vk::texture_info config_texture = {
+        .phsyical_memory_properties = physical_device.memory_properties(),
+    };
+    vk::texture texture1(logical_device,
+                         std::filesystem::path("asset_samples/viking_room.png"),
+                         config_texture);
+
+    std::array<vk::write_image, 1> samplers = {
+        vk::write_image{
+          .sampler = texture1.image().sampler(),
+          .view = texture1.image().image_view(),
+          .layout = vk::image_layout::shader_read_only_optimal,
+        },
+    };
+
+    // Specify image descriptor images/samplers to the descriptor
+    std::array<vk::write_image_descriptor, 1> set1_samples = {
+        vk::write_image_descriptor{
+          .dst_binding = 0,
+          .sample_images = samplers,
+        }
+    };
+    set0_resource.update(uniforms);
+
+    set1_resource.update({}, set1_samples);
+
+    while (!glfwWindowShouldClose(window)) {
+        glfwPollEvents();
+
+        uint32_t current_frame = presentation_queue.acquire_next_image();
+        vk::command_buffer current = swapchain_command_buffers[current_frame];
+
+        current.begin(vk::command_usage::simulatneous_use_bit);
+
+        // renderpass begin/end must be within a recording command buffer
+        vk::renderpass_begin_params begin_renderpass = {
+            .extent = swapchain_extent,
+            .current_framebuffer = swapchain_framebuffers[current_frame],
+            .color = color,
+            .subpass = vk::subpass_contents::inline_bit
+        };
+        main_renderpass.begin(current, begin_renderpass);
+
+        // Binding a graphics pipeline -- before drawing stuff
+        // Inside of this graphics pipeline bind, is where you want to do the
+        // drawing stuff to
+        main_graphics_pipeline.bind(current);
+
+        // Must be binded before descriptor resource gets binded
+        test_model.bind(current);
+
+        static auto start_time = std::chrono::high_resolution_clock::now();
+
+        auto current_time = std::chrono::high_resolution_clock::now();
+        float time = std::chrono::duration<float, std::chrono::seconds::period>(
+                       current_time - start_time)
+                       .count();
+
+        // We set the uniforms and then we offload that to the GPU
+        global_uniform ubo = {
+            .model = glm::rotate(glm::mat4(1.0f),
+                                 time * glm::radians(90.0f),
+                                 glm::vec3(0.0f, 0.0f, 1.0f)),
+            .view = glm::lookAt(glm::vec3(2.0f, 2.0f, 2.0f),
+                                glm::vec3(0.0f, 0.0f, 0.0f),
+                                glm::vec3(0.0f, 0.0f, 1.0f)),
+            .proj = glm::perspective(glm::radians(45.0f),
+                                     (float)swapchain_extent.width /
+                                       (float)swapchain_extent.height,
+                                     0.1f,
+                                     10.0f)
+        };
+        ubo.proj[1][1] *= -1;
+
+        std::array<global_uniform, 1> ubo_arr = { ubo };
+        test_ubo.transfer<global_uniform>(ubo_arr);
+
+        // Before we can send stuff to the GPU, since we already updated the
+        // descriptor set 0 beforehand, we must bind that descriptor resource
+        // before making any of the draw calls Something to note: You cannot
+        // update descriptor sets in the process of a current-recording command
+        // buffers or else that becomes undefined behavior
+        // set0_resource.bind(current, main_graphics_pipeline.layout());
+
+        std::array<const VkDescriptorSet, 2> descriptors = { set0_resource,
+                                                             set1_resource };
+
+        current.bind_descriptors(main_graphics_pipeline.layout(),
+                                 VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                 descriptors);
+
+        // Drawing-call to render actual triangle to the screen
+        // vkCmdDrawIndexed(current, static_cast<uint32_t>(indices.size()), 1,
+        // 0, 0, 0);
+        test_model.draw(current);
+
+        main_renderpass.end(current);
+        current.end();
+
+        // Submitting and then presenting to the screen
+        std::array<const VkCommandBuffer, 1> commands = { current };
+        // presentation_queue.submit_async(current);
+        presentation_queue.submit_async(commands);
+        presentation_queue.present_frame(current_frame);
+    }
+
+    // this to ensure they are cleaned up in the proper order
+    logical_device.wait();
+    main_swapchain.destroy();
+
+    texture1.destroy();
+    set0_resource.destroy();
+    set1_resource.destroy();
+    test_ubo.destroy();
+    test_model.destroy();
+
+    for (auto& command : swapchain_command_buffers) {
+        command.destroy();
+    }
+
+    for (auto& fb : swapchain_framebuffers) {
+        fb.destroy();
+    }
+
+    for (auto& image : swapchain_images) {
+        image.destroy();
+    }
+
+    for (auto& depth_img : swapchain_depth_images) {
+        depth_img.destroy();
+    }
+
+    main_graphics_pipeline.destroy();
+    geometry_resource.destroy();
+    main_renderpass.destroy();
+    presentation_queue.destroy();
+
+    logical_device.destroy();
+    window_surface.destroy();
+    glfwDestroyWindow(window);
+    api_instance.destroy();
+    return 0;
+}

--- a/demos/14-imgui/conanfile.py
+++ b/demos/14-imgui/conanfile.py
@@ -1,0 +1,37 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+
+class Demo(ConanFile):
+    name = "game-demo"
+    version = "1.0"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    export_source = "CMakeLists.txt", "application.cpp"
+
+    # Putting all of your build-related dependencies here
+    def build_requirements(self):
+        self.tool_requires("cmake/[^4.0.0]")
+        self.tool_requires("ninja/[^1.3.0]")
+        self.tool_requires("engine3d-cmake-utils/4.0")
+
+    # Putting all of your packages here
+    # To build engine3d/1.0 locally do the following:
+    # conan create . --name=engine3d --version=0.1.0 --user=local --channel=12345
+    def requirements(self):
+        self.requires("glfw/3.4")
+        self.requires("glm/1.0.1")
+        self.requires("stb/cci.20230920")
+        self.requires("tinyobjloader/2.0.0-rc10")
+        self.requires("vulkan-cpp/6.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+    
+    def layout(self):
+        cmake_layout(self)

--- a/vulkan-cpp/command_buffer.cppm
+++ b/vulkan-cpp/command_buffer.cppm
@@ -166,6 +166,152 @@ export namespace vk {
             }
 
             /**
+             * @brief Transferring the raw geomtric data of vertices to the
+             * vertex input stage of the graphics pipeline.
+             *
+             * This implies when starting to draw, to look at specific buffers
+             * to find the vertex attributes (position, normals, and color for
+             * each vertex)
+             *
+             * Unlike descriptor sets, vertex buffers are high-frequent data
+             * reads automatically by the hardware input's assembler for every
+             * vertex being processed.
+             *
+             * @param p_buffers an arbitrary span of buffers containg vertex
+             * attribute data.
+             * @param p_first_binding is the index of the first vertex binding
+             * to update (usually 0).
+             * @param p_offsets is a span of byte offsets specifying where the
+             * actual data begins inside each buffer.
+             *
+             * @brief Additional Consideration:
+             * - Number of buffers and their order MUST match what is specified
+             * with using `VkVertexInputBindingDescription` or
+             * `vk::vertex_attribute` specifications.
+             * - Size of `p_buffers` and `p_offsets` must be identical . Where
+             * each buffer needs a starting offset.
+             * - Every buffer MUST need to be created using
+             * `VK_BUFFER_USAGE_VERTEX_BUFFER_BIT`.
+             * - Data in these transfers
+             *
+             *
+             * Example Usage:
+             *
+             * ```C++
+             *
+             * vk::command_buffer current = ...;
+             *
+             * std::array<VkBuffer, 1> vertex = { vbo };
+             * uint64_t offset = 0;
+             * current.bind_vertex_buffers(vertex, std::span<uint64_t>(&offset,
+             * 1));
+             * ```
+             *
+             */
+            void bind_vertex_buffers(std::span<const VkBuffer> p_buffers,
+                                     std::span<const uint64_t> p_offsets = {},
+                                     const uint32_t p_first_binding = 0) {
+                vkCmdBindVertexBuffers(m_command_buffer,
+                                       p_first_binding,
+                                       static_cast<uint32_t>(p_buffers.size()),
+                                       p_buffers.data(),
+                                       p_offsets.data());
+            }
+
+            /**
+             * @brief Command tells the GPU what amount of bytes are stored in
+             * the indices for rendering.
+             *
+             * @param p_index_buffer is the handle containing the array of
+             * indices
+             * @param p_offset is the byte starting point (usually 0 unless you
+             * store multiple meshes in one buffer).
+             *
+             * @brief Additional Consideration:
+             * - Chosen API (8-bit, 16-bit, 32-bit) must match the bit-width of
+             * your data. If you bind a 32-bit buffer as 16-bit, the GPU will
+             * read twice as many indices, but each will be complete bad data.
+             * - .p_offset: must be aligned to size of the index type (e.g.
+             * p_offset % 4 == 0 for uint32).
+             *
+             * [ Index Buffer (memory) ]            [ GPU Input Assembly ]
+             * +-----------------------+            +--------------------+
+             * | [0] [1] [2]           | --Bind-->  | Indices Sequencer, |
+             * | [2] [3] [0]           |            | State              |
+             * +-----------------------+            +--------------------+
+             * (Indices 0, 1, 2, ... 5)              (Select Vertices Order)
+             *
+             */
+
+            /**
+             * @brief Used 1 byte per index.
+             *
+             * Minimal memory, limited to 256 vertices.
+             *
+             * Example Usage:
+             * ```C++
+             *
+             * vk::command_buffer current = ...;
+             *
+             * vk::index_buffer8 ibo = ...;
+             * current.bind_index_buffer8(ibo);
+             * ```
+             *
+             */
+            void bind_index_buffers8(const VkBuffer p_index_buffer,
+                                     const uint64_t p_offset = 0) {
+                vkCmdBindIndexBuffer(m_command_buffer,
+                                     p_index_buffer,
+                                     p_offset,
+                                     VK_INDEX_TYPE_UINT8);
+            }
+
+            /**
+             * @brief Use 2 bytes per index.
+             *
+             * Can be used for most 3D models up to 65k verties.
+             *
+             * ```C++
+             *
+             * vk::command_buffer current = ...;
+             *
+             * vk::index_buffer16 ibo = ...;
+             * current.bind_index_buffer16(ibo);
+             * ```
+             *
+             */
+            void bind_index_buffers16(const VkBuffer p_index_buffer,
+                                      const uint64_t p_offset = 0) {
+                vkCmdBindIndexBuffer(m_command_buffer,
+                                     p_index_buffer,
+                                     p_offset,
+                                     VK_INDEX_TYPE_UINT16);
+            }
+
+            /**
+             * @brief Use 4 bytes per index.
+             *
+             * Used for more higher-density terrain for complex meshes such as
+             * terrain.
+             *
+             * ```C++
+             *
+             * vk::command_buffer current = ...;
+             *
+             * vk::index_buffer32 ibo = ...;
+             * current.bind_index_buffer32(ibo);
+             * ```
+             *
+             */
+            void bind_index_buffers32(const VkBuffer p_index_buffer,
+                                      const uint64_t p_offset = 0) {
+                vkCmdBindIndexBuffer(m_command_buffer,
+                                     p_index_buffer,
+                                     p_offset,
+                                     VK_INDEX_TYPE_UINT32);
+            }
+
+            /**
              * @brief Bind the current data that stored in memory to the
              * active descriptor set for execution.
              *

--- a/vulkan-cpp/index_buffer.cppm
+++ b/vulkan-cpp/index_buffer.cppm
@@ -41,11 +41,6 @@ export namespace vk {
 
             [[nodiscard]] bool alive() const { return m_index_buffer; }
 
-            void bind(const VkCommandBuffer& p_current, uint64_t p_offset = 0) {
-                vkCmdBindIndexBuffer(
-                  p_current, m_index_buffer, p_offset, VK_INDEX_TYPE_UINT32);
-            }
-
             operator VkBuffer() const { return m_index_buffer; }
 
             operator VkBuffer() { return m_index_buffer; }

--- a/vulkan-cpp/vertex_buffer.cppm
+++ b/vulkan-cpp/vertex_buffer.cppm
@@ -113,13 +113,6 @@ export namespace vk {
 
             [[nodiscard]] bool alive() const { return m_vertex_handler; }
 
-            void bind(const VkCommandBuffer& p_current) {
-                std::array<VkBuffer, 1> handlers = { m_vertex_handler };
-                VkDeviceSize offsets[] = { 0 };
-                vkCmdBindVertexBuffers(
-                  p_current, 0, 1, handlers.data(), offsets);
-            }
-
             // TODO: Probably handle flushing in vk::buffer_stream to give
             // support for this...?
             // void write(std::span<const vertex_input> p_vertices) {}


### PR DESCRIPTION
This PR has changes involving the binding API's for the descriptors. I originally thought it made sense to have binding API's for descriptor sets.

Later realized that this responsibility should be given to the `vk::command_buffer` to provide an API to control the arbitrary amount of descriptors to binding the resources to.
