### PR TITLE
Minor Fixes

### DIFF
--- a/vulkan-cpp/texture.cppm
+++ b/vulkan-cpp/texture.cppm
@@ -157,7 +157,7 @@ export namespace vk {
                 m_image = create_texture_with_data(
                   m_device,
                   config_image,
-                  std::span<const uint8_t>(white_color, image_size));
+                  std::span<const uint8_t>(white_color.data(), image_size));
                 m_texture_loaded = true;
             }
 
@@ -178,8 +178,6 @@ export namespace vk {
                             &h,
                             &channels,
                             STBI_rgb_alpha);
-                // m_width = static_cast<uint32_t>(w);
-                // m_height = static_cast<uint32_t>(h);
                 m_extent = {
                     .width = static_cast<uint32_t>(w),
                     .height = static_cast<uint32_t>(h),
@@ -193,7 +191,7 @@ export namespace vk {
                 // with bytes per pixel
                 // uint32_t layer_size_with_bytes =
                 uint32_t image_layer_sizes_with_bytes =
-                  m_width * m_height * bytes_per_pixel;
+                  m_extent.width * m_extent.height * bytes_per_pixel;
 
                 // uint32_t layer_count = 1;
                 uint32_t layer_count = p_texture_info.layer_count;
@@ -224,6 +222,8 @@ export namespace vk {
                   config_image,
                   std::span<uint8_t>(image_pixel_data, image_size));
 
+                // Proper cleanup of the image data
+                stbi_image_free(image_pixel_data);
                 m_texture_loaded = true;
             }
 

--- a/vulkan-cpp/texture.cppm
+++ b/vulkan-cpp/texture.cppm
@@ -24,19 +24,11 @@ export namespace vk {
         sample_image create_texture_with_data(const VkDevice& p_device,
                                               const image_params& p_config,
                                               std::span<const uint8_t> p_data) {
-            // 1. Creating temporary command buffer for texture
-            command_params copy_command_params = {
-                .levels = command_levels::primary,
-                .queue_index = 0,
-                .flags = command_pool_flags::reset,
-            };
-            command_buffer temp_command_buffer =
-              command_buffer(p_device, copy_command_params);
 
-            // 2. loading texture
+            // 1. loading texture
             sample_image texture_image = sample_image(p_device, p_config);
 
-            // 3. transfer data from staging buffer
+            // 2. transfer data from staging buffer
             uint32_t property_flag = memory_property::host_visible_bit |
                                      memory_property::host_cached_bit;
 
@@ -49,13 +41,22 @@ export namespace vk {
             buffer_stream staging(
               p_device, p_data.size(), staging_buffer_config);
 
-            // 4. write data to the staging buffer with specific size specified
+            // 3. write data to the staging buffer with specific size specified
             staging.transfer(p_data);
 
-            // 5. start recording to this command buffer
+            // 4. start recording to this command buffer
             VkImageLayout old_layout = VK_IMAGE_LAYOUT_UNDEFINED;
             VkImageLayout new_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             VkFormat texture_format = p_config.format;
+
+            // 5. Creating temporary command buffer for texture
+            command_params copy_command_params = {
+                .levels = command_levels::primary,
+                .queue_index = 0,
+                .flags = command_pool_flags::reset,
+            };
+            command_buffer temp_command_buffer =
+              command_buffer(p_device, copy_command_params);
 
             temp_command_buffer.begin(command_usage::one_time_submit);
 
@@ -128,18 +129,15 @@ export namespace vk {
             texture(const VkDevice& p_device,
                     const image_extent& p_extent,
                     VkPhysicalDeviceMemoryProperties p_property)
-              : m_device(p_device) {
+              : m_device(p_device)
+              , m_extent(p_extent) {
 
                 // 1.) Load in extent dimensions
                 // White pixels for storing texture.
                 std::array<uint8_t, 4> white_color = { 0xFF, 0xFF, 0xFF, 0xFF };
 
-                m_width = p_extent.width;
-                m_height = p_extent.height;
-
                 image_params config_image = {
-                    .extent = p_extent,
-                    // .format = VK_FORMAT_R8G8B8A8_UNORM,
+                    .extent = m_extent,
                     .format = static_cast<VkFormat>(format::r8g8b8a8_unorm),
                     .usage =
                       image_usage::transfer_dst_bit | image_usage::sampled_bit,
@@ -156,9 +154,10 @@ export namespace vk {
                 uint32_t layer_count = 1;
                 uint32_t image_size = layer_size_with_bytes * layer_count;
 
-                std::span<const uint8_t> bytes(white_color.data(), image_size);
-                m_image =
-                  create_texture_with_data(m_device, config_image, bytes);
+                m_image = create_texture_with_data(
+                  m_device,
+                  config_image,
+                  std::span<const uint8_t>(white_color, image_size));
                 m_texture_loaded = true;
             }
 
@@ -179,23 +178,31 @@ export namespace vk {
                             &h,
                             &channels,
                             STBI_rgb_alpha);
+                // m_width = static_cast<uint32_t>(w);
+                // m_height = static_cast<uint32_t>(h);
+                m_extent = {
+                    .width = static_cast<uint32_t>(w),
+                    .height = static_cast<uint32_t>(h),
+                };
 
-                m_width = w;
-                m_height = h;
+                const VkFormat texture_format =
+                  static_cast<VkFormat>(format::r8g8b8a8_unorm);
+                int bytes_per_pixel = bytes_per_texture_format(texture_format);
 
-                if (!image_pixel_data) {
-                    m_texture_loaded = false;
-                    return;
-                }
+                // Ensuring we get pass in the correct image size
+                // with bytes per pixel
+                // uint32_t layer_size_with_bytes =
+                uint32_t image_layer_sizes_with_bytes =
+                  m_width * m_height * bytes_per_pixel;
 
-                // 2. create vulkan image handlers + loading in the image data
-                uint32_t property_flag = memory_property::device_local_bit;
+                // uint32_t layer_count = 1;
+                uint32_t layer_count = p_texture_info.layer_count;
+                uint32_t image_size =
+                  image_layer_sizes_with_bytes * layer_count;
 
                 image_params config_image = {
-                    .extent = { .width = static_cast<uint32_t>(w),
-                                .height = static_cast<uint32_t>(h) },
-                    // .format = VK_FORMAT_R8G8B8A8_UNORM,
-                    .format = static_cast<VkFormat>(format::r8g8b8a8_unorm),
+                    .extent = m_extent,
+                    .format = texture_format,
                     .usage =
                       image_usage::transfer_dst_bit | image_usage::sampled_bit,
                     .mip_levels = p_texture_info.mip_levels,
@@ -203,34 +210,30 @@ export namespace vk {
                     .phsyical_memory_properties =
                       p_texture_info.phsyical_memory_properties,
                 };
-                int bytes_per_pixel =
-                  bytes_per_texture_format(config_image.format);
 
-                // Ensuring we get pass in the correct image size with bytes per
-                // pixel
-                uint32_t layer_size_with_bytes = config_image.extent.width *
-                                                 config_image.extent.height *
-                                                 bytes_per_pixel;
-                uint32_t layer_count = 1;
-                uint32_t image_size = layer_size_with_bytes * layer_count;
+                // Ensures the image data is valid before continuing
+                // We can check the state of the image if it loaded succesfully
+                if (!image_pixel_data) {
+                    m_texture_loaded = false;
+                    return;
+                }
 
-                // Validating the correct amount of data to creating the texture
-                // with
-                std::span<const uint8_t> bytes(
-                  as_bytes(image_pixel_data, image_size));
-                m_image =
-                  create_texture_with_data(p_device, config_image, bytes);
+                // Creating Image Handle + Loading Image Pixel Data
+                m_image = create_texture_with_data(
+                  p_device,
+                  config_image,
+                  std::span<uint8_t>(image_pixel_data, image_size));
 
                 m_texture_loaded = true;
             }
 
+            //! @return true if image loaded, false if texture did not load
+            //! correctly
             [[nodiscard]] bool loaded() const { return m_texture_loaded; }
 
             [[nodiscard]] sample_image image() const { return m_image; }
 
-            [[nodiscard]] uint32_t width() const { return m_width; }
-
-            [[nodiscard]] uint32_t height() const { return m_height; }
+            [[nodiscard]] image_extent extent() const { return m_extent; }
 
             void destroy() { m_image.destroy(); }
 
@@ -238,8 +241,7 @@ export namespace vk {
             VkDevice m_device = nullptr;
             bool m_texture_loaded = false;
             sample_image m_image{};
-            uint32_t m_width = 0;
-            uint32_t m_height = 0;
+            image_extent m_extent{};
         };
     };
 };

--- a/vulkan-cpp/utilities.cppm
+++ b/vulkan-cpp/utilities.cppm
@@ -312,16 +312,6 @@ export namespace vk {
         }
 
         /**
-         * @brief API to work with types that comes from C
-         * 
-         * TODO: May remove this due to some inguarantees of what the 
-        */
-        std::span<const uint8_t> as_bytes(const void* p_data, uint32_t p_size) {
-            const auto* bytes = reinterpret_cast<const uint8_t*>(p_data);
-            return std::span<const uint8_t>(bytes, p_size);
-        }
-
-        /**
          * @brief GPU memory is optimized differently for different tasks. An
          * image optimized for 'Transfer Destination' (filling with bytes) can
          * be look different in memory then an image configured for 'Shader Read

--- a/vulkan-cpp/utilities.cppm
+++ b/vulkan-cpp/utilities.cppm
@@ -298,16 +298,97 @@ export namespace vk {
                     (p_format == VK_FORMAT_D24_UNORM_S8_UINT));
         }
 
+        /**
+         * @brief Used to convert a given set of types T into chunks of bytes.
+         *
+         * This is used for the vulkan-cpp API's that expect to take in a
+         * span<const uint8_t> to transfer data over to the Vulkan C API, that
+         * expects a void*.
+         */
         template<typename T>
         std::span<uint8_t> to_bytes(T p_data) {
             return std::span<uint8_t>(reinterpret_cast<uint8_t*>(&p_data),
                                       sizeof(p_data));
         }
 
+        /**
+         * @brief API to work with types that comes from C
+         * 
+         * TODO: May remove this due to some inguarantees of what the 
+        */
         std::span<const uint8_t> as_bytes(const void* p_data, uint32_t p_size) {
             const auto* bytes = reinterpret_cast<const uint8_t*>(p_data);
             return std::span<const uint8_t>(bytes, p_size);
         }
+
+        /**
+         * @brief GPU memory is optimized differently for different tasks. An
+         * image optimized for 'Transfer Destination' (filling with bytes) can
+         * be look different in memory then an image configured for 'Shader Read
+         * Only'.
+         *
+         * This API performs a transition operation which 'reformats' the image
+         * data at the hardware-level.
+         *
+         * Usually acts as a syncing point, ensuring the GPU finishes writing to
+         * the image before it makes an attempt to read from it.
+         *
+         * [ Image Memory ]           [ Transition ]         [ Image Memory ]
+         * +------------------+    +----------------+    +---------------------+
+         * | Layout: Undefined|    | Memory Flush   |    | Layout: Shader Read |
+         * | Access: 0        | => | Layout Reformat| => | Access: Shader Read |
+         * | (Initial/Invalid)|    | Exec Stall     |    | (For Sampling       |
+         * +------------------+    +----------------+    +---------------------+
+         *
+         * @brief Additional Consideration:
+         * - uses vkQueueWaitIdle, which stalls the CPU until the GPU is idle.
+         * - Only used for initialization or infrequent updates.
+         * - Use vk::image_layout::undefined as the old layout is faster but
+         * discards pixel data.
+         * - Transition applies to the entire subresource range (all
+         * mips/layers) defined within the p_image barrier logic.
+         *
+         */
+        /*
+        void transition_image_layout(VkDevice p_device,
+                                     vk::sample_image& p_image,
+                                     VkFormat p_format,
+                                     VkImageLayout p_old,
+                                     VkImageLayout p_new) {
+            vk::command_params copy_command_params = {
+                .levels = vk::command_levels::primary,
+                .queue_index = 0,
+                .flags = vk::command_pool_flags::reset,
+            };
+            vk::command_buffer temp_command_buffer =
+              vk::command_buffer(p_device, copy_command_params);
+
+            temp_command_buffer.begin(vk::command_usage::one_time_submit);
+
+            p_image.memory_barrier(temp_command_buffer, p_format, p_old, p_new);
+
+            temp_command_buffer.end();
+
+            VkCommandBuffer handle = temp_command_buffer;
+            VkSubmitInfo submit_info = {
+                .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                .commandBufferCount = 1,
+                .pCommandBuffers = &handle,
+            };
+
+            uint32_t queue_family_index = 0;
+            uint32_t queue_index = 0;
+            VkQueue temp_graphics_queue;
+            vkGetDeviceQueue(
+              p_device, queue_family_index, queue_index, &temp_graphics_queue);
+
+            vkQueueSubmit(temp_graphics_queue, 1, &submit_info, nullptr);
+            vkQueueWaitIdle(temp_graphics_queue);
+
+            temp_command_buffer.destroy();
+        }
+        */ 
+        
 
     }; // end of v1 namespace
 };

--- a/vulkan-cpp/utilities.cppm
+++ b/vulkan-cpp/utilities.cppm
@@ -377,8 +377,7 @@ export namespace vk {
 
             temp_command_buffer.destroy();
         }
-        */ 
-        
+        */
 
     }; // end of v1 namespace
 };


### PR DESCRIPTION
This PR just contains some code cleanup and minor refactor to the `vk::texture` implementation.

I did some code cleanup because there was some logic duplication and made sure there was more consistency in using `vk::image_extent` for image-specific logic.