### PR TITLE
Add Vulkan Features Chains Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PROJECT_NAME} PUBLIC
     TYPE CXX_MODULES
     FILES
     vulkan-cpp/vk.cppm
+    vulkan-cpp/feature_extensions.cppm
     vulkan-cpp/types.cppm
     vulkan-cpp/utilities.cppm
     vulkan-cpp/instance.cppm

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -314,7 +314,19 @@ main() {
     std::array<const char*, 1> extensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
 #endif
 
+    vk::device_features device_features{
+        vk::descriptor_indexing_feature{{
+            .descriptorBindingPartiallyBound = true,
+            .descriptorBindingVariableDescriptorCount = true,
+            .descriptorBindingSampledImageUpdateAfterBind = true,
+        } },
+        vk::dynamic_rendering_feature{ {
+          .dynamicRendering = true,
+        } },
+    };
+
     vk::device_params logical_device_params = {
+        .features = device_features.data(),
         .queue_priorities = priorities,
         .extensions = extensions,
         .queue_family_index = 0,
@@ -701,8 +713,7 @@ main() {
         };
         ubo.proj[1][1] *= -1;
 
-        std::array<global_uniform, 1> ubo_arr = { ubo };
-        test_ubo.transfer<global_uniform>(ubo_arr);
+        test_ubo.transfer<global_uniform>(std::span<const global_uniform>(&ubo, 1));
 
         // Before we can send stuff to the GPU, since we already updated the
         // descriptor set 0 beforehand, we must bind that descriptor resource

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -315,10 +315,10 @@ main() {
 #endif
 
     vk::device_features device_features{
-        vk::descriptor_indexing_feature{{
-            .descriptorBindingPartiallyBound = true,
-            .descriptorBindingVariableDescriptorCount = true,
-            .descriptorBindingSampledImageUpdateAfterBind = true,
+        vk::descriptor_indexing_feature{ {
+          .descriptorBindingPartiallyBound = true,
+          .descriptorBindingVariableDescriptorCount = true,
+          .descriptorBindingSampledImageUpdateAfterBind = true,
         } },
         vk::dynamic_rendering_feature{ {
           .dynamicRendering = true,
@@ -713,7 +713,8 @@ main() {
         };
         ubo.proj[1][1] *= -1;
 
-        test_ubo.transfer<global_uniform>(std::span<const global_uniform>(&ubo, 1));
+        test_ubo.transfer<global_uniform>(
+          std::span<const global_uniform>(&ubo, 1));
 
         // Before we can send stuff to the GPU, since we already updated the
         // descriptor set 0 beforehand, we must bind that descriptor resource

--- a/vulkan-cpp/device.cppm
+++ b/vulkan-cpp/device.cppm
@@ -35,7 +35,8 @@ export namespace vk {
 
                 VkDeviceCreateInfo create_info = {
                     .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-                    .pNext = nullptr,
+                    // .pNext = nullptr,
+                    .pNext = p_config.features,
                     .flags = 0,
                     .queueCreateInfoCount = 1,
                     .pQueueCreateInfos = &device_queue_ci,

--- a/vulkan-cpp/feature_extensions.cppm
+++ b/vulkan-cpp/feature_extensions.cppm
@@ -53,8 +53,8 @@ export namespace vk {
     };
 
     /**
-     * @brief a trait that can be aliased to an 
-    */
+     * @brief a trait that can be aliased to an
+     */
     template<typename T, VkStructureType SType>
     struct feature_trait : public T {
 
@@ -64,53 +64,58 @@ export namespace vk {
         }
     };
 
-    // These are shorthand aliases that already setup the features 
+    // Descriptor indexing to access unbounded array of a given uniform
     using descriptor_indexing_feature = feature_trait<
       VkPhysicalDeviceDescriptorIndexingFeatures,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
-    using dynamic_rendering = feature_trait<
+
+    //! @brief Modernized Vulkan feature that reduces state managing for
+    //! renderpasses + framebuffers
+    using dynamic_rendering_feature = feature_trait<
       VkPhysicalDeviceDynamicRenderingFeatures,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
 
-    template<ExtensionConcept T, ExtensionConcept... Features>
-    void internal_data(T& head, Features&... tail) {
-        /**
-         * @brief Passing an arbitrary sequences of
-         * VkPhysicalDevice*Features
-         *
-         *
-         * @brief Handled using Variadic Templates
-         * Compiler does not generate a loop, rather it'll generate a flat
-         * sequence of instructions.
-         *
-         * Essentially doing something like:
-         * chain_features(descriptor_indexing, dynamic_rendering).
-         *
-         * The compiler will automatically assign the chaining .pNext
-         * pointer per sequence: (where it will automatically assign the
-         * .pNext pointer per feature specified in it's sequence) 1.)
-         * current.pNext = &descriptor_indexing 2.)
-         * descriptor_indexing.pNext = &dynamic_rendering
-         *
-         */
-        auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
-        ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
-            current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
-            ...);
-        current->pNext = nullptr;
-    }
+    //! @brief Represent buffers as direct pointer in shaders
+    // using buffer_device_address_feature = feature_trait<
+    //   VkPhysicalDeviceBufferAddressFeatures,
+    //   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES>;
+
+    //! @brief Modernize approach for bindless techniques
+    using descriptor_buffer_feature = feature_trait<
+      VkPhysicalDeviceDescriptorBufferFeaturesEXT,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT>;
+
+    //! @brief Updating descriptors similar fashion as push constants
+    using push_descriptors_feature = feature_trait<
+      VkPhysicalDevicePushDescriptorPropertiesKHR,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR>;
+
+    //! @brief Feature that can skip monolith pipeline objects
+    using shader_object_feature = feature_trait<
+      VkPhysicalDeviceShaderObjectFeaturesEXT,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT>;
+
+    //! @brief Handled dynamic pipeline states
+    using pipeline_library = feature_trait<
+      VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT>;
+
+    //! @brief Clean barriers and semaphores
+    using sync2_feature = feature_trait<
+      VkPhysicalDeviceSynchronization2Features,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES>;
 
     template<ExtensionConcept... Features>
-    struct device_features {
+    class device_features {
     public:
         device_features(Features&&... p_args)
           : m_data(std::forward<Features>(p_args)...) {
 
-            // We take our unpacked structure of vulkan features
+            // Check unpacked structures of vulkan features
             // Then we chain the pNext pointer altogether for each feature we
-            // unpack
+            // unpack if there are any
             if constexpr (sizeof...(Features) > 0) {
-                std::apply([](auto&... spec) { internal_data(spec...); },
+                std::apply([this](auto&... spec) { chain_features(spec...); },
                            m_data);
             }
         }
@@ -131,12 +136,84 @@ export namespace vk {
          */
         [[nodiscard]] void* data() noexcept {
 
-            // This just ensures the data that
+            // At compile-time we retrieve the head pointer of the entire
+            // feature list chain altogether.
             if constexpr (sizeof...(Features) > 0) {
                 return &std::get<0>(m_data);
             }
 
             return nullptr;
+        }
+
+    private:
+        /**
+         * @brief Vulkan uses a linked-list specifying lists of features to
+         * enable.
+         *
+         * This linked-list feature is used to enable modern GPU features. This
+         * internal API allows to take in a collection of structs that are
+         * inter-connected them into a single chain the internal API's can read
+         * from.
+         *
+         * The pNext used for chaining
+         *
+         * [ Feature A ]      [ Feature B ]     [ Feature N ]
+         * +------------+     +------------+    +-----------+
+         * | .sType     |     | .sType     |    | .sType    |
+         * | .pNext     | --> | .pNext     | -> | .pNext    |
+         * +------------+     +------------+    +-----------+
+         * ( head )             ( internal )     ( tail )
+         *
+         * Example Usage:
+         *
+         * ```C++
+         *
+         * vk::device_features device_features{
+         *    vk::descriptor_indexing_feature{{
+         *        .descriptorBindingPartiallyBound = true,
+         *        .descriptorBindingVariableDescriptorCount = true,
+         *        .descriptorBindingSampledImageUpdateAfterBind = true,
+         *    } },
+         *    vk::dynamic_rendering{ {
+         *    .dynamicRendering = true,
+         *    } },
+         * };
+         *
+         * vk::device_params config_logical_device = {
+         *      .features = device_features,
+         * };
+         *
+         * ```
+         *
+         *
+         */
+        template<ExtensionConcept T, ExtensionConcept... Feature>
+        void chain_features(T& head, Feature&... tail) {
+            /**
+             * @brief Passing an arbitrary sequences of
+             * VkPhysicalDevice*Features
+             *
+             *
+             * @brief Handled using Variadic Templates
+             * Compiler does not generate a loop, rather it'll generate a flat
+             * sequence of instructions.
+             *
+             * Essentially doing something like:
+             * chain_features(descriptor_indexing, dynamic_rendering).
+             *
+             * The compiler will automatically assign the chaining .pNext
+             * pointer per sequence: (where it will automatically assign the
+             * .pNext pointer per feature specified in it's sequence)
+             *
+             * 1.) current.pNext = &descriptor_indexing
+             * 2.) descriptor_indexing.pNext = &dynamic_rendering
+             *
+             */
+            auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
+            ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
+              current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
+             ...);
+            current->pNext = nullptr;
         }
 
     private:

--- a/vulkan-cpp/feature_extensions.cppm
+++ b/vulkan-cpp/feature_extensions.cppm
@@ -55,32 +55,34 @@ namespace vk {
         { t.pNext } -> std::convertible_to<void*>;
     };
 
-    template<ExtensionConcept T, ExtensionConcept... Args>
-    void chain_features(T& head, Args&... tail) {
-        /**
-         * @brief Passing an arbitrary sequences of VkPhysicalDevice*Features
-         *
-         *
-         * @brief Handled using Variadic Templates
-         * Compiler does not generate a loop, rather it'll generate a flat
-         * sequence of instructions.
-         *
-         * Essentially doing something like: chain_features(descriptor_indexing,
-         * dynamic_rendering).
-         *
-         * The compiler will automatically assign the chaining .pNext pointer
-         * per sequence: (where it will automatically assign the .pNext pointer
-         * per feature specified in it's sequence) 1.) current.pNext =
-         * &descriptor_indexing 2.) descriptor_indexing.pNext =
-         * &dynamic_rendering
-         *
-         */
-        auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
-        ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
-          current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
-         ...);
-        current->pNext = nullptr;
-    }
+    // template<ExtensionConcept T, ExtensionConcept... Args>
+    // void chain_features(T& head, Args&... tail) {
+    //     /**
+    //      * @brief Passing an arbitrary sequences of VkPhysicalDevice*Features
+    //      *
+    //      *
+    //      * @brief Handled using Variadic Templates
+    //      * Compiler does not generate a loop, rather it'll generate a flat
+    //      * sequence of instructions.
+    //      *
+    //      * Essentially doing something like:
+    //      chain_features(descriptor_indexing,
+    //      * dynamic_rendering).
+    //      *
+    //      * The compiler will automatically assign the chaining .pNext pointer
+    //      * per sequence: (where it will automatically assign the .pNext
+    //      pointer
+    //      * per feature specified in it's sequence) 1.) current.pNext =
+    //      * &descriptor_indexing 2.) descriptor_indexing.pNext =
+    //      * &dynamic_rendering
+    //      *
+    //      */
+    //     auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
+    //     ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
+    //       current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
+    //      ...);
+    //     current->pNext = nullptr;
+    // }
 
     template<typename T, VkStructureType STYPE>
     struct feature_type : public T {
@@ -90,6 +92,7 @@ namespace vk {
         }
     };
 
+    // TEMP: Use for testing
     using descriptor_indexing_feature = feature_type<
       VkPhysicalDeviceDescriptorIndexingFeatures,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
@@ -131,58 +134,36 @@ namespace vk {
         }
 
     private:
-        std::tuple<Features...> m_data;
-    };
-
-    template<typename T, VkStructureType STYPE>
-    struct feature_type : public T {
-        explicit feature_type(T p_intiializer)
-          : T(p_intiializer) {
-            this->sType = STYPE;
-        }
-    };
-
-    using descriptor_indexing_feature = feature_type<
-      VkPhysicalDeviceDescriptorIndexingFeatures,
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
-    using dynamic_rendering = feature_type<
-      VkPhysicalDeviceDynamicRenderingFeatures,
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
-
-    template<ExtensionConcept... Features>
-    struct features {
-    public:
-        features(Features&&... p_args)
-          : m_data(std::forward<Features>(p_args)...) {
-
-            // We take our unpacked structure of vulkan features
-            // Then we chain the pNext pointer altogether for each feature we
-            // unpack
-            if constexpr (sizeof...(Features) > 0) {
-                std::apply([](auto&... spec) { chain_features(spec...); },
-                           m_data);
-            }
-        }
-
-        /**
-         * @brief We provide the chained pNext ptr
-         *
-         * This will let us directly have the chained features the user can
-         * specify.
-         *
-         * @return nullptr if no features are specified, returns the pNext
-         * feature chain otherwise.
-         *
-         */
-        [[nodiscard]] void* get_head() noexcept {
-            if constexpr (sizeof...(Features) > 0) {
-                return &std::get<0>(m_data);
-            }
-
-            return nullptr;
+        template<typename T>
+        void chain_pointers(T& head, Features&... tail) {
+            /**
+             * @brief Passing an arbitrary sequences of
+             * VkPhysicalDevice*Features
+             *
+             *
+             * @brief Handled using Variadic Templates
+             * Compiler does not generate a loop, rather it'll generate a flat
+             * sequence of instructions.
+             *
+             * Essentially doing something like:
+             * chain_features(descriptor_indexing, dynamic_rendering).
+             *
+             * The compiler will automatically assign the chaining .pNext
+             * pointer per sequence: (where it will automatically assign the
+             * .pNext pointer per feature specified in it's sequence) 1.)
+             * current.pNext = &descriptor_indexing 2.)
+             * descriptor_indexing.pNext = &dynamic_rendering
+             *
+             */
+            auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
+            ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
+              current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
+             ...);
+            current->pNext = nullptr;
         }
 
     private:
         std::tuple<Features...> m_data;
     };
+
 };

--- a/vulkan-cpp/feature_extensions.cppm
+++ b/vulkan-cpp/feature_extensions.cppm
@@ -3,22 +3,11 @@ module;
 #include <concepts>
 #include <type_traits>
 #include <tuple>
+#include <vulkan/vulkan.h>
 
-export module vk::feature_extensions;
+export module vk:feature_extensions;
 
-namespace vk {
-
-    //! @brief Provide additional compile-time verification checks
-    template<typename DeviceFeature>
-    struct feature_trait : std::false_type {};
-
-    template<>
-    struct feature_trait<VkPhysicalDeviceDescriptorIndexingFeatures>
-      : std::true_type {};
-
-    template<>
-    struct feature_trait<VkPhysicalDeviceDynamicRenderingFeatures>
-      : std::true_type {};
+export namespace vk {
 
     /**
      * @brief ExtensionConcept being a concept
@@ -56,11 +45,6 @@ namespace vk {
      * ONLY the vulkan feature struct static_assert(*this, "Invalid vulkan
      * feature specified. Only accepting valid vulkan features.");
      * };
-     *
-     *
-     * template<>
-     * struct device_feature<VkPhysicalDeviceDescriptorIndexingFeatures> :
-     * public std::true_type {};
      */
     template<typename T>
     concept ExtensionConcept = requires(T t) {
@@ -68,21 +52,53 @@ namespace vk {
         { t.pNext } -> std::convertible_to<void*>;
     };
 
-    template<typename T, VkStructureType STYPE>
-    struct feature_type : public T {
-        explicit feature_type(T p_intiializer)
-          : T(p_intiializer) {
-            this->sType = STYPE;
+    /**
+     * @brief a trait that can be aliased to an 
+    */
+    template<typename T, VkStructureType SType>
+    struct feature_trait : public T {
+
+        feature_trait(T p_initialize_feature)
+          : T(p_initialize_feature) {
+            this->sType = SType;
         }
     };
 
-    // TEMP: Use for testing
-    using descriptor_indexing_feature = feature_type<
+    // These are shorthand aliases that already setup the features 
+    using descriptor_indexing_feature = feature_trait<
       VkPhysicalDeviceDescriptorIndexingFeatures,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
-    using dynamic_rendering = feature_type<
+    using dynamic_rendering = feature_trait<
       VkPhysicalDeviceDynamicRenderingFeatures,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
+
+    template<ExtensionConcept T, ExtensionConcept... Features>
+    void internal_data(T& head, Features&... tail) {
+        /**
+         * @brief Passing an arbitrary sequences of
+         * VkPhysicalDevice*Features
+         *
+         *
+         * @brief Handled using Variadic Templates
+         * Compiler does not generate a loop, rather it'll generate a flat
+         * sequence of instructions.
+         *
+         * Essentially doing something like:
+         * chain_features(descriptor_indexing, dynamic_rendering).
+         *
+         * The compiler will automatically assign the chaining .pNext
+         * pointer per sequence: (where it will automatically assign the
+         * .pNext pointer per feature specified in it's sequence) 1.)
+         * current.pNext = &descriptor_indexing 2.)
+         * descriptor_indexing.pNext = &dynamic_rendering
+         *
+         */
+        auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
+        ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
+            current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
+            ...);
+        current->pNext = nullptr;
+    }
 
     template<ExtensionConcept... Features>
     struct device_features {
@@ -113,7 +129,7 @@ namespace vk {
          *
          * Will return nullptr if no extensions are enabled.
          */
-        [[nodiscard]] void* data() const noexcept {
+        [[nodiscard]] void* data() noexcept {
 
             // This just ensures the data that
             if constexpr (sizeof...(Features) > 0) {
@@ -121,41 +137,6 @@ namespace vk {
             }
 
             return nullptr;
-        }
-
-        // Deleting copy and move semantics
-        // This can cause the internal address members to change, which we do
-        // not want.
-        device_features(const device_features&) = delete;
-        device_features& operator=(const device_features&) = delete;
-
-    private:
-        template<typename T>
-        void internal_data(T& head, Features&... tail) {
-            /**
-             * @brief Passing an arbitrary sequences of
-             * VkPhysicalDevice*Features
-             *
-             *
-             * @brief Handled using Variadic Templates
-             * Compiler does not generate a loop, rather it'll generate a flat
-             * sequence of instructions.
-             *
-             * Essentially doing something like:
-             * chain_features(descriptor_indexing, dynamic_rendering).
-             *
-             * The compiler will automatically assign the chaining .pNext
-             * pointer per sequence: (where it will automatically assign the
-             * .pNext pointer per feature specified in it's sequence) 1.)
-             * current.pNext = &descriptor_indexing 2.)
-             * descriptor_indexing.pNext = &dynamic_rendering
-             *
-             */
-            auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
-            ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
-              current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
-             ...);
-            current->pNext = nullptr;
         }
 
     private:

--- a/vulkan-cpp/feature_extensions.cppm
+++ b/vulkan-cpp/feature_extensions.cppm
@@ -7,6 +7,19 @@ module;
 export module vk::feature_extensions;
 
 namespace vk {
+
+    //! @brief Provide additional compile-time verification checks
+    template<typename DeviceFeature>
+    struct feature_trait : std::false_type {};
+
+    template<>
+    struct feature_trait<VkPhysicalDeviceDescriptorIndexingFeatures>
+      : std::true_type {};
+
+    template<>
+    struct feature_trait<VkPhysicalDeviceDynamicRenderingFeatures>
+      : std::true_type {};
+
     /**
      * @brief ExtensionConcept being a concept
      *
@@ -55,35 +68,6 @@ namespace vk {
         { t.pNext } -> std::convertible_to<void*>;
     };
 
-    // template<ExtensionConcept T, ExtensionConcept... Args>
-    // void chain_features(T& head, Args&... tail) {
-    //     /**
-    //      * @brief Passing an arbitrary sequences of VkPhysicalDevice*Features
-    //      *
-    //      *
-    //      * @brief Handled using Variadic Templates
-    //      * Compiler does not generate a loop, rather it'll generate a flat
-    //      * sequence of instructions.
-    //      *
-    //      * Essentially doing something like:
-    //      chain_features(descriptor_indexing,
-    //      * dynamic_rendering).
-    //      *
-    //      * The compiler will automatically assign the chaining .pNext pointer
-    //      * per sequence: (where it will automatically assign the .pNext
-    //      pointer
-    //      * per feature specified in it's sequence) 1.) current.pNext =
-    //      * &descriptor_indexing 2.) descriptor_indexing.pNext =
-    //      * &dynamic_rendering
-    //      *
-    //      */
-    //     auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
-    //     ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
-    //       current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
-    //      ...);
-    //     current->pNext = nullptr;
-    // }
-
     template<typename T, VkStructureType STYPE>
     struct feature_type : public T {
         explicit feature_type(T p_intiializer)
@@ -101,16 +85,16 @@ namespace vk {
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
 
     template<ExtensionConcept... Features>
-    struct features {
+    struct device_features {
     public:
-        features(Features&&... p_args)
+        device_features(Features&&... p_args)
           : m_data(std::forward<Features>(p_args)...) {
 
             // We take our unpacked structure of vulkan features
             // Then we chain the pNext pointer altogether for each feature we
             // unpack
             if constexpr (sizeof...(Features) > 0) {
-                std::apply([](auto&... spec) { chain_features(spec...); },
+                std::apply([](auto&... spec) { internal_data(spec...); },
                            m_data);
             }
         }
@@ -124,8 +108,14 @@ namespace vk {
          * @return nullptr if no features are specified, returns the pNext
          * feature chain otherwise.
          *
+         * @returns the internal data of the vulkan device extensions that are
+         * chained altogether.
+         *
+         * Will return nullptr if no extensions are enabled.
          */
-        [[nodiscard]] void* get_head() noexcept {
+        [[nodiscard]] void* data() const noexcept {
+
+            // This just ensures the data that
             if constexpr (sizeof...(Features) > 0) {
                 return &std::get<0>(m_data);
             }
@@ -133,9 +123,15 @@ namespace vk {
             return nullptr;
         }
 
+        // Deleting copy and move semantics
+        // This can cause the internal address members to change, which we do
+        // not want.
+        device_features(const device_features&) = delete;
+        device_features& operator=(const device_features&) = delete;
+
     private:
         template<typename T>
-        void chain_pointers(T& head, Features&... tail) {
+        void internal_data(T& head, Features&... tail) {
             /**
              * @brief Passing an arbitrary sequences of
              * VkPhysicalDevice*Features

--- a/vulkan-cpp/feature_extensions.cppm
+++ b/vulkan-cpp/feature_extensions.cppm
@@ -1,0 +1,188 @@
+module;
+
+#include <concepts>
+#include <type_traits>
+#include <tuple>
+
+export module vk::feature_extensions;
+
+namespace vk {
+    /**
+     * @brief ExtensionConcept being a concept
+     *
+     * Used for mainly performing compile-time checks if the features specified
+     * are actual valid features
+     *
+     * Because Vulkan is a C API and .pNext being a void*. This can be bug-prone
+     * for accidentally pointing to a type that is not a feature struct like a
+     * std::string, for example.
+     *
+     * VulkanChainable concept is used to verify the conditions of the type that
+     * is being passed to chain_features.
+     *
+     * Which is important to ensure that we only accept types that do contain
+     * .sType and .pNext
+     *
+     * TODO: Probably might have this be a template specialization due to being
+     * able to verify at compile-time if the vulkan features, we need to check
+     * for are valid. This way even if the struct has `.sType` and `.pNext`, we
+     * can at least verify the struct is a feature that is valid
+     *
+     *
+     * Example:
+     *
+     * ```C++
+     *
+     * // This trait should be false by default
+     * // Meaning if you reach this, then it should error out
+     * template<typename T>
+     * struct device_feature : public std::false_type {
+     *      // Having this be a compiler-error by default if this struct is
+     * reached.
+     *      // Users should not be allowed to supply a non vulkan feature struct
+     * ONLY the vulkan feature struct static_assert(*this, "Invalid vulkan
+     * feature specified. Only accepting valid vulkan features.");
+     * };
+     *
+     *
+     * template<>
+     * struct device_feature<VkPhysicalDeviceDescriptorIndexingFeatures> :
+     * public std::true_type {};
+     */
+    template<typename T>
+    concept ExtensionConcept = requires(T t) {
+        { t.sType } -> std::convertible_to<VkStructureType>;
+        { t.pNext } -> std::convertible_to<void*>;
+    };
+
+    template<ExtensionConcept T, ExtensionConcept... Args>
+    void chain_features(T& head, Args&... tail) {
+        /**
+         * @brief Passing an arbitrary sequences of VkPhysicalDevice*Features
+         *
+         *
+         * @brief Handled using Variadic Templates
+         * Compiler does not generate a loop, rather it'll generate a flat
+         * sequence of instructions.
+         *
+         * Essentially doing something like: chain_features(descriptor_indexing,
+         * dynamic_rendering).
+         *
+         * The compiler will automatically assign the chaining .pNext pointer
+         * per sequence: (where it will automatically assign the .pNext pointer
+         * per feature specified in it's sequence) 1.) current.pNext =
+         * &descriptor_indexing 2.) descriptor_indexing.pNext =
+         * &dynamic_rendering
+         *
+         */
+        auto* current = reinterpret_cast<VkBaseOutStructure*>(&head);
+        ((current->pNext = reinterpret_cast<VkBaseOutStructure*>(&tail),
+          current = reinterpret_cast<VkBaseOutStructure*>(&tail)),
+         ...);
+        current->pNext = nullptr;
+    }
+
+    template<typename T, VkStructureType STYPE>
+    struct feature_type : public T {
+        explicit feature_type(T p_intiializer)
+          : T(p_intiializer) {
+            this->sType = STYPE;
+        }
+    };
+
+    using descriptor_indexing_feature = feature_type<
+      VkPhysicalDeviceDescriptorIndexingFeatures,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
+    using dynamic_rendering = feature_type<
+      VkPhysicalDeviceDynamicRenderingFeatures,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
+
+    template<ExtensionConcept... Features>
+    struct features {
+    public:
+        features(Features&&... p_args)
+          : m_data(std::forward<Features>(p_args)...) {
+
+            // We take our unpacked structure of vulkan features
+            // Then we chain the pNext pointer altogether for each feature we
+            // unpack
+            if constexpr (sizeof...(Features) > 0) {
+                std::apply([](auto&... spec) { chain_features(spec...); },
+                           m_data);
+            }
+        }
+
+        /**
+         * @brief We provide the chained pNext ptr
+         *
+         * This will let us directly have the chained features the user can
+         * specify.
+         *
+         * @return nullptr if no features are specified, returns the pNext
+         * feature chain otherwise.
+         *
+         */
+        [[nodiscard]] void* get_head() noexcept {
+            if constexpr (sizeof...(Features) > 0) {
+                return &std::get<0>(m_data);
+            }
+
+            return nullptr;
+        }
+
+    private:
+        std::tuple<Features...> m_data;
+    };
+
+    template<typename T, VkStructureType STYPE>
+    struct feature_type : public T {
+        explicit feature_type(T p_intiializer)
+          : T(p_intiializer) {
+            this->sType = STYPE;
+        }
+    };
+
+    using descriptor_indexing_feature = feature_type<
+      VkPhysicalDeviceDescriptorIndexingFeatures,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES>;
+    using dynamic_rendering = feature_type<
+      VkPhysicalDeviceDynamicRenderingFeatures,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES>;
+
+    template<ExtensionConcept... Features>
+    struct features {
+    public:
+        features(Features&&... p_args)
+          : m_data(std::forward<Features>(p_args)...) {
+
+            // We take our unpacked structure of vulkan features
+            // Then we chain the pNext pointer altogether for each feature we
+            // unpack
+            if constexpr (sizeof...(Features) > 0) {
+                std::apply([](auto&... spec) { chain_features(spec...); },
+                           m_data);
+            }
+        }
+
+        /**
+         * @brief We provide the chained pNext ptr
+         *
+         * This will let us directly have the chained features the user can
+         * specify.
+         *
+         * @return nullptr if no features are specified, returns the pNext
+         * feature chain otherwise.
+         *
+         */
+        [[nodiscard]] void* get_head() noexcept {
+            if constexpr (sizeof...(Features) > 0) {
+                return &std::get<0>(m_data);
+            }
+
+            return nullptr;
+        }
+
+    private:
+        std::tuple<Features...> m_data;
+    };
+};

--- a/vulkan-cpp/types.cppm
+++ b/vulkan-cpp/types.cppm
@@ -10,6 +10,8 @@ module;
 
 export module vk:types;
 
+import :feature_extensions;
+
 export namespace vk {
     inline namespace v1 {
         enum format : uint32_t {
@@ -536,6 +538,7 @@ export namespace vk {
         };
 
         struct device_params {
+            void* features{};
             std::span<float> queue_priorities{};
             std::span<const char*>
               extensions{}; // Can add VK_KHR_SWAPCHAIN_EXTENSION_NAME to this

--- a/vulkan-cpp/vk.cppm
+++ b/vulkan-cpp/vk.cppm
@@ -3,6 +3,7 @@ export module vk;
 export import :types;
 export import :instance;
 export import :physical_device;
+export import :feature_extensions;
 export import :device;
 export import :device_queue;
 export import :surface;


### PR DESCRIPTION
This PR resolves #33 .

It is because Vulkan features is they require users to have chain their struct of features using the `pNext` pointer that points to the next chain.

The following changes in this PR contains the API's for specifying the Vulkan features and automating assigning the `pNext` pointer.

The following is included:
* Performing compile-time validation for Vulkan-specific features using C++20 concepts.
* Compile-time chaining the pNext pointer and removing responsibility from user-space.

