### PR TITLE
fix: Expose `dst_array_element` for write descriptors + additional cleanup for `vk::buffer_parameters`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: 🛠️ CI
 
 on: [pull_request]
 
+
 jobs:
   clang-format:
     uses: engine3d-dev/ci/.github/workflows/clang-format.yml@main
@@ -11,19 +12,19 @@ jobs:
     uses: engine3d-dev/ci/.github/workflows/windows.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.0"
+      version: "6.1"
     secrets: inherit
 
   linux:
     uses: engine3d-dev/ci/.github/workflows/linux.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.0"
+      version: "6.1"
     secrets: inherit
 
   mac:
     uses: engine3d-dev/ci/.github/workflows/mac.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.0"
+      version: "6.1"
     secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.2.0"
 
 class VulkanCppRecipe(ConanFile):
     name = "vulkan-cpp"
-    version = "6.0"
+    version = "6.1"
     license = "Apache-2.0"
     url = "https://github.com/engine3d-dev/vulkan-cpp"
     homepage = "https://github.com/engine3d-dev/vulkan-cpp"

--- a/demos/1-instance/conanfile.py
+++ b/demos/1-instance/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/10-textures/application.cpp
+++ b/demos/10-textures/application.cpp
@@ -473,13 +473,12 @@ main() {
         }
     };
     //! @brief Creating vertex/index buffers with host visibility flags
-    const auto property_flags =
-      static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-                                       vk::memory_property::host_cached_bit);
 
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::device_local_bit,
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::device_local_bit |
+          vk::memory_property::host_visible_bit),
+        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -488,10 +487,12 @@ main() {
     std::array<uint32_t, 6> indices = { 0, 1, 2, 2, 3, 0 };
 
     vk::buffer_parameters index_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = static_cast<vk::memory_property>(
+        .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
+        // .property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/10-textures/application.cpp
+++ b/demos/10-textures/application.cpp
@@ -478,7 +478,6 @@ main() {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::device_local_bit |
           vk::memory_property::host_visible_bit),
-        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -490,19 +489,15 @@ main() {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
-        // .property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);
 
     // Setting up descriptor sets for handling uniforms
     vk::buffer_parameters uniform_params = {
-        .memory_mask =
-          physical_device.memory_properties(static_cast<vk::memory_property>(
-            vk::memory_property::host_visible_bit |
-            vk::memory_property::host_cached_bit)),
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::host_visible_bit |
+          vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::uniform_buffer_bit,
     };
     vk::uniform_buffer test_ubo = vk::uniform_buffer(

--- a/demos/10-textures/conanfile.py
+++ b/demos/10-textures/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/11-depth-buffering/application.cpp
+++ b/demos/11-depth-buffering/application.cpp
@@ -525,16 +525,10 @@ main() {
         }
     };
 
-    //! @brief Setting host visibility property flags
-    const auto property_flags =
-      static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-                                       vk::memory_property::host_cached_bit);
-
     // Creating vertex buffers
     vk::buffer_parameters vertex_params = {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -546,8 +540,6 @@ main() {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
-        // .property_flags = vk::memory_property::host_visible_bit |
-        //                   vk::memory_property::host_cached_bit,
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/11-depth-buffering/application.cpp
+++ b/demos/11-depth-buffering/application.cpp
@@ -528,7 +528,8 @@ main() {
     // Creating vertex buffers
     vk::buffer_parameters vertex_params = {
         .memory_mask = physical_device.memory_properties(
-          vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+          vk::memory_property::device_local_bit |
+          vk::memory_property::host_visible_bit),
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };

--- a/demos/11-depth-buffering/application.cpp
+++ b/demos/11-depth-buffering/application.cpp
@@ -532,8 +532,9 @@ main() {
 
     // Creating vertex buffers
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::device_local_bit,
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -542,9 +543,11 @@ main() {
     // Creating index buffers
     std::array<uint32_t, 12> indices = { 0, 1, 2, 2, 3, 0, 4, 5, 6, 6, 7, 4 };
     vk::buffer_parameters index_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::host_visible_bit |
-                          vk::memory_property::host_cached_bit,
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::host_visible_bit |
+          vk::memory_property::host_cached_bit),
+        // .property_flags = vk::memory_property::host_visible_bit |
+        //                   vk::memory_property::host_cached_bit,
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/11-depth-buffering/conanfile.py
+++ b/demos/11-depth-buffering/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -163,7 +163,8 @@ public:
         //! @brief Creating vertex/index buffers with host visibility flags
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
-              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+              vk::memory_property::device_local_bit |
+              vk::memory_property::host_visible_bit),
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -161,14 +161,9 @@ public:
         m_indices_size = indices.size();
 
         //! @brief Creating vertex/index buffers with host visibility flags
-        // const auto property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit);
-
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
@@ -177,9 +172,6 @@ public:
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = static_cast<vk::memory_property>(
-            //   vk::memory_property::host_visible_bit |
-            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/12-loading-models/application.cpp
+++ b/demos/12-loading-models/application.cpp
@@ -161,22 +161,25 @@ public:
         m_indices_size = indices.size();
 
         //! @brief Creating vertex/index buffers with host visibility flags
-        const auto property_flags = static_cast<vk::memory_property>(
-          vk::memory_property::host_visible_bit |
-          vk::memory_property::host_cached_bit);
+        // const auto property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit);
 
         vk::buffer_parameters vertex_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = vk::memory_property::device_local_bit,
+            .memory_mask = p_physical.memory_properties(
+              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
 
         vk::buffer_parameters index_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = static_cast<vk::memory_property>(
+            .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
+            // .property_flags = static_cast<vk::memory_property>(
+            //   vk::memory_property::host_visible_bit |
+            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/12-loading-models/conanfile.py
+++ b/demos/12-loading-models/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/13-skybox/conanfile.py
+++ b/demos/13-skybox/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/13-skybox/environment_map.cppm
+++ b/demos/13-skybox/environment_map.cppm
@@ -81,9 +81,9 @@ public:
             .memory_mask = m_physical_device->memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            .property_flags = static_cast<vk::memory_property>(
-              vk::memory_property::host_visible_bit |
-              vk::memory_property::host_cached_bit),
+            // .property_flags = static_cast<vk::memory_property>(
+            //   vk::memory_property::host_visible_bit |
+            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::transfer_src_bit,
         };
 
@@ -331,8 +331,8 @@ public:
             .memory_mask = m_physical_device->memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            .property_flags = vk::memory_property::host_visible_bit |
-                              vk::memory_property::host_cached_bit,
+            // .property_flags = vk::memory_property::host_visible_bit |
+            //                   vk::memory_property::host_cached_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/13-skybox/environment_map.cppm
+++ b/demos/13-skybox/environment_map.cppm
@@ -81,9 +81,6 @@ public:
             .memory_mask = m_physical_device->memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = static_cast<vk::memory_property>(
-            //   vk::memory_property::host_visible_bit |
-            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::transfer_src_bit,
         };
 
@@ -104,11 +101,6 @@ public:
         m_skybox_image = vk::sample_image(m_device, skybox_image_params);
 
         // Transferring data from the CPU
-        // void* data = nullptr;
-        // vkMapMemory(m_device, staging_memory, 0, total_size_bytes, 0,
-        // &data); std::memcpy(data, pixels,
-        // static_cast<size_t>(total_size_bytes)); vkUnmapMemory(m_device,
-        // staging_memory);
         std::span<const uint8_t> pixels_data(
           reinterpret_cast<const uint8_t*>(pixels), image_size);
         staging_buffer.transfer(pixels_data);
@@ -331,8 +323,6 @@ public:
             .memory_mask = m_physical_device->memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = vk::memory_property::host_visible_bit |
-            //                   vk::memory_property::host_cached_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/14-imgui/application.cpp
+++ b/demos/14-imgui/application.cpp
@@ -166,7 +166,8 @@ public:
 
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
-              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+              vk::memory_property::device_local_bit |
+              vk::memory_property::host_visible_bit),
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/14-imgui/application.cpp
+++ b/demos/14-imgui/application.cpp
@@ -165,15 +165,15 @@ public:
           vk::memory_property::host_cached_bit);
 
         vk::buffer_parameters vertex_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = vk::memory_property::device_local_bit,
+            .memory_mask = p_physical.memory_properties(
+              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
 
         vk::buffer_parameters index_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = static_cast<vk::memory_property>(
+            .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,

--- a/demos/14-imgui/application.cpp
+++ b/demos/14-imgui/application.cpp
@@ -167,7 +167,6 @@ public:
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/14-imgui/conanfile.py
+++ b/demos/14-imgui/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/15-dynamic-rendering/application.cpp
+++ b/demos/15-dynamic-rendering/application.cpp
@@ -156,22 +156,25 @@ public:
         m_indices_size = indices.size();
 
         //! @brief Creating vertex/index buffers with host visibility flags
-        const auto property_flags = static_cast<vk::memory_property>(
-          vk::memory_property::host_visible_bit |
-          vk::memory_property::host_cached_bit);
+        // const auto property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit);
 
         vk::buffer_parameters vertex_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = vk::memory_property::device_local_bit,
+            .memory_mask = p_physical.memory_properties(
+              vk::memory_property::device_local_bit),
+            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
 
         vk::buffer_parameters index_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = static_cast<vk::memory_property>(
+            .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
+            // .property_flags = static_cast<vk::memory_property>(
+            //   vk::memory_property::host_visible_bit |
+            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/15-dynamic-rendering/application.cpp
+++ b/demos/15-dynamic-rendering/application.cpp
@@ -155,15 +155,9 @@ public:
         m_indices_size = vertices.size();
         m_indices_size = indices.size();
 
-        //! @brief Creating vertex/index buffers with host visibility flags
-        // const auto property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit);
-
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::device_local_bit),
-            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
@@ -172,9 +166,6 @@ public:
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = static_cast<vk::memory_property>(
-            //   vk::memory_property::host_visible_bit |
-            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/15-dynamic-rendering/conanfile.py
+++ b/demos/15-dynamic-rendering/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/16-descriptor-indexing/application.cpp
+++ b/demos/16-descriptor-indexing/application.cpp
@@ -165,17 +165,21 @@ public:
           vk::memory_property::host_cached_bit);
 
         vk::buffer_parameters vertex_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = vk::memory_property::device_local_bit,
+            .memory_mask = p_physical.memory_properties(
+              vk::memory_property::device_local_bit |
+              vk::memory_property::host_visible_bit),
+            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
 
         vk::buffer_parameters index_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = static_cast<vk::memory_property>(
+            .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
+            // .property_flags = static_cast<vk::memory_property>(
+            //   vk::memory_property::host_visible_bit |
+            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/16-descriptor-indexing/application.cpp
+++ b/demos/16-descriptor-indexing/application.cpp
@@ -168,7 +168,6 @@ public:
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::device_local_bit |
               vk::memory_property::host_visible_bit),
-            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
@@ -177,9 +176,6 @@ public:
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = static_cast<vk::memory_property>(
-            //   vk::memory_property::host_visible_bit |
-            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/16-descriptor-indexing/conanfile.py
+++ b/demos/16-descriptor-indexing/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/17-buffer-device-address/application.cpp
+++ b/demos/17-buffer-device-address/application.cpp
@@ -163,7 +163,8 @@ public:
 
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
-              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+              vk::memory_property::device_local_bit |
+              vk::memory_property::host_visible_bit),
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };

--- a/demos/17-buffer-device-address/application.cpp
+++ b/demos/17-buffer-device-address/application.cpp
@@ -162,22 +162,25 @@ public:
         m_indices_size = indices.size();
 
         //! @brief Creating vertex/index buffers with host visibility flags
-        const auto property_flags = static_cast<vk::memory_property>(
-          vk::memory_property::host_visible_bit |
-          vk::memory_property::host_cached_bit);
+        // const auto property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit);
 
         vk::buffer_parameters vertex_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = vk::memory_property::device_local_bit,
+            .memory_mask = p_physical.memory_properties(
+              vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
 
         vk::buffer_parameters index_params = {
-            .memory_mask = p_physical.memory_properties(property_flags),
-            .property_flags = static_cast<vk::memory_property>(
+            .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
+            // .property_flags = static_cast<vk::memory_property>(
+            //   vk::memory_property::host_visible_bit |
+            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/17-buffer-device-address/application.cpp
+++ b/demos/17-buffer-device-address/application.cpp
@@ -161,15 +161,9 @@ public:
         m_indices_size = vertices.size();
         m_indices_size = indices.size();
 
-        //! @brief Creating vertex/index buffers with host visibility flags
-        // const auto property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit);
-
         vk::buffer_parameters vertex_params = {
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-            // .property_flags = vk::memory_property::device_local_bit,
             .usage = vk::buffer_usage::transfer_dst_bit |
                      vk::buffer_usage::vertex_buffer_bit,
         };
@@ -178,9 +172,6 @@ public:
             .memory_mask = p_physical.memory_properties(
               vk::memory_property::host_visible_bit |
               vk::memory_property::host_cached_bit),
-            // .property_flags = static_cast<vk::memory_property>(
-            //   vk::memory_property::host_visible_bit |
-            //   vk::memory_property::host_cached_bit),
             .usage = vk::buffer_usage::index_buffer_bit,
         };
 

--- a/demos/17-buffer-device-address/conanfile.py
+++ b/demos/17-buffer-device-address/conanfile.py
@@ -20,7 +20,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/2-physical-device/conanfile.py
+++ b/demos/2-physical-device/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/3-logical-device/conanfile.py
+++ b/demos/3-logical-device/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/4-surface/conanfile.py
+++ b/demos/4-surface/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/5-swapchain/conanfile.py
+++ b/demos/5-swapchain/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/6-graphics-pipeline/conanfile.py
+++ b/demos/6-graphics-pipeline/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/7-vertex-buffer/application.cpp
+++ b/demos/7-vertex-buffer/application.cpp
@@ -311,7 +311,9 @@ main() {
     };
 
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::device_local_bit |
+          vk::memory_property::host_visible_bit),
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };

--- a/demos/7-vertex-buffer/application.cpp
+++ b/demos/7-vertex-buffer/application.cpp
@@ -310,12 +310,8 @@ main() {
         }
     };
 
-    // const auto property_flags =
-    //   static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-    //                                    vk::memory_property::host_cached_bit);
     vk::buffer_parameters vertex_params = {
         .memory_mask = physical_device.memory_properties(vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };

--- a/demos/7-vertex-buffer/application.cpp
+++ b/demos/7-vertex-buffer/application.cpp
@@ -310,12 +310,12 @@ main() {
         }
     };
 
-    const auto property_flags =
-      static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-                                       vk::memory_property::host_cached_bit);
+    // const auto property_flags =
+    //   static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
+    //                                    vk::memory_property::host_cached_bit);
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::device_local_bit,
+        .memory_mask = physical_device.memory_properties(vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };

--- a/demos/7-vertex-buffer/conanfile.py
+++ b/demos/7-vertex-buffer/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/8-index-uniform-buffers/application.cpp
+++ b/demos/8-index-uniform-buffers/application.cpp
@@ -333,14 +333,11 @@ main() {
         },
     };
 
-    const auto property_flags =
-      static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-                                       vk::memory_property::host_cached_bit);
-
     // Creating vertex buffers
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::device_local_bit,
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
+        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -349,10 +346,12 @@ main() {
     // Creating index buffer
     std::array<uint32_t, 6> indices = { 0, 1, 2, 2, 3, 0 };
     vk::buffer_parameters index_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = static_cast<vk::memory_property>(
+        .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
+        // .property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/8-index-uniform-buffers/application.cpp
+++ b/demos/8-index-uniform-buffers/application.cpp
@@ -336,8 +336,8 @@ main() {
     // Creating vertex buffers
     vk::buffer_parameters vertex_params = {
         .memory_mask = physical_device.memory_properties(
-          vk::memory_property::device_local_bit | vk::memory_property::host_visible_bit),
-        // .property_flags = vk::memory_property::device_local_bit,
+          vk::memory_property::device_local_bit |
+          vk::memory_property::host_visible_bit),
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -349,9 +349,6 @@ main() {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
-        // .property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/8-index-uniform-buffers/conanfile.py
+++ b/demos/8-index-uniform-buffers/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/9-uniforms/application.cpp
+++ b/demos/9-uniforms/application.cpp
@@ -368,14 +368,17 @@ main() {
           .color = { 1.0f, 1.0f, 1.0f },
         }
     };
-    const auto property_flags =
-      static_cast<vk::memory_property>(vk::memory_property::host_visible_bit |
-                                       vk::memory_property::host_cached_bit);
+    // const auto property_flags =
+    //   static_cast<vk::memory_property>(vk::memory_property::host_visible_bit
+    //   |
+    //                                    vk::memory_property::host_cached_bit);
 
     // Creating vertex buffer
     vk::buffer_parameters vertex_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = vk::memory_property::device_local_bit,
+        .memory_mask = physical_device.memory_properties(
+          vk::memory_property::device_local_bit |
+          vk::memory_property::host_visible_bit),
+        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -384,10 +387,12 @@ main() {
     // Creating index buffer
     std::array<uint32_t, 6> indices = { 0, 1, 2, 2, 3, 0 };
     vk::buffer_parameters index_params = {
-        .memory_mask = physical_device.memory_properties(property_flags),
-        .property_flags = static_cast<vk::memory_property>(
+        .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
+        // .property_flags = static_cast<vk::memory_property>(
+        //   vk::memory_property::host_visible_bit |
+        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/9-uniforms/application.cpp
+++ b/demos/9-uniforms/application.cpp
@@ -368,17 +368,12 @@ main() {
           .color = { 1.0f, 1.0f, 1.0f },
         }
     };
-    // const auto property_flags =
-    //   static_cast<vk::memory_property>(vk::memory_property::host_visible_bit
-    //   |
-    //                                    vk::memory_property::host_cached_bit);
 
     // Creating vertex buffer
     vk::buffer_parameters vertex_params = {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::device_local_bit |
           vk::memory_property::host_visible_bit),
-        // .property_flags = vk::memory_property::device_local_bit,
         .usage = vk::buffer_usage::transfer_dst_bit |
                  vk::buffer_usage::vertex_buffer_bit,
     };
@@ -390,9 +385,6 @@ main() {
         .memory_mask = physical_device.memory_properties(
           vk::memory_property::host_visible_bit |
           vk::memory_property::host_cached_bit),
-        // .property_flags = static_cast<vk::memory_property>(
-        //   vk::memory_property::host_visible_bit |
-        //   vk::memory_property::host_cached_bit),
         .usage = vk::buffer_usage::index_buffer_bit,
     };
     vk::index_buffer test_ibo(logical_device, indices, index_params);

--- a/demos/9-uniforms/conanfile.py
+++ b/demos/9-uniforms/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.0")
+        self.requires("vulkan-cpp/6.1")
 
     def build(self):
         cmake = CMake(self)

--- a/vulkan-cpp/descriptor_resource.cppm
+++ b/vulkan-cpp/descriptor_resource.cppm
@@ -273,11 +273,9 @@ export namespace vk {
              *
              * vk::descriptor_resource set0(logical_device, layout);
              *
-             * // Uniform Buffers Handle
-             * std::array<vk::write_buffer, 1> uniforms0 = {
-             *  vk::write_buffer{
-             *       .buffer = test_ubo,
-             *       .offset = 0,
+             * // Specify the uniform handles to perform update operations with
+             * the descriptor set specified std::array<vk::write_buffer, 1>
+             * uniforms0 = { vk::write_buffer{ .buffer = test_ubo, .offset = 0,
              *      .range = static_cast<uint32_t>(test_ubo.size_bytes()),
              *  },
              * };
@@ -320,7 +318,9 @@ export namespace vk {
                 std::unordered_map<uint32_t, std::vector<VkDescriptorImageInfo>>
                   image_infos;
 
-                // handle uniforms
+                // Reconfigure the VkWriteDescriptorBufferInfo with the
+                // parameters accroding vk::write_buffer_descriptor
+                // specifications
                 for (const auto& ubo : p_uniforms) {
                     for (const auto& uniform : ubo.uniforms) {
                         buffer_infos[ubo.dst_binding].emplace_back(
@@ -332,7 +332,7 @@ export namespace vk {
                         .pNext = nullptr,
                         .dstSet = m_descriptor_set,
                         .dstBinding = ubo.dst_binding,
-                        .dstArrayElement = 0,
+                        .dstArrayElement = ubo.dst_array_element,
                         .descriptorCount = static_cast<uint32_t>(
                           buffer_infos[ubo.dst_binding].size()),
                         .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
@@ -356,7 +356,7 @@ export namespace vk {
                         .pNext = nullptr,
                         .dstSet = m_descriptor_set,
                         .dstBinding = ubo.dst_binding,
-                        .dstArrayElement = 0,
+                        .dstArrayElement = ubo.dst_array_element,
                         .descriptorCount = static_cast<uint32_t>(
                           image_infos[ubo.dst_binding].size()),
                         .descriptorType =
@@ -375,8 +375,8 @@ export namespace vk {
                   nullptr);
 
                 // Ensures to clear up so we dont have any existing handles
-                // because they only need to exist until we've updated the
-                // descriptors
+                // because they only need to exist until we've updated this
+                // descriptor set in particular
                 buffer_infos.clear();
                 image_infos.clear();
             }

--- a/vulkan-cpp/texture.cppm
+++ b/vulkan-cpp/texture.cppm
@@ -70,8 +70,6 @@ export namespace vk {
                 // Performing staging transfers
                 buffer_parameters staging_options = {
                     .memory_mask = img_options.memory_mask,
-                    // .property_flags = memory_property::host_visible_bit |
-                    //                   memory_property::host_cached_bit,
                     .usage = buffer_usage::transfer_src_bit,
                 };
                 buffer staging(m_device, p_data.size(), staging_options);
@@ -156,14 +154,9 @@ export namespace vk {
 
                 m_image = sample_image(m_device, img_options);
 
-                // Setup staging buffer
-                // uint32_t property_flag = memory_property::host_visible_bit |
-                //                          memory_property::host_cached_bit;
-
+                // Staging buffer to transfer CPU-visible data to GPU-visible handles
                 buffer_parameters staging_options = {
                     .memory_mask = img_options.memory_mask,
-                    // .property_flags =
-                    //   static_cast<memory_property>(property_flag),
                     .usage = buffer_usage::transfer_src_bit,
                 };
                 buffer staging(

--- a/vulkan-cpp/texture.cppm
+++ b/vulkan-cpp/texture.cppm
@@ -70,8 +70,8 @@ export namespace vk {
                 // Performing staging transfers
                 buffer_parameters staging_options = {
                     .memory_mask = img_options.memory_mask,
-                    .property_flags = memory_property::host_visible_bit |
-                                      memory_property::host_cached_bit,
+                    // .property_flags = memory_property::host_visible_bit |
+                    //                   memory_property::host_cached_bit,
                     .usage = buffer_usage::transfer_src_bit,
                 };
                 buffer staging(m_device, p_data.size(), staging_options);
@@ -157,13 +157,13 @@ export namespace vk {
                 m_image = sample_image(m_device, img_options);
 
                 // Setup staging buffer
-                uint32_t property_flag = memory_property::host_visible_bit |
-                                         memory_property::host_cached_bit;
+                // uint32_t property_flag = memory_property::host_visible_bit |
+                //                          memory_property::host_cached_bit;
 
                 buffer_parameters staging_options = {
                     .memory_mask = img_options.memory_mask,
-                    .property_flags =
-                      static_cast<memory_property>(property_flag),
+                    // .property_flags =
+                    //   static_cast<memory_property>(property_flag),
                     .usage = buffer_usage::transfer_src_bit,
                 };
                 buffer staging(

--- a/vulkan-cpp/texture.cppm
+++ b/vulkan-cpp/texture.cppm
@@ -154,7 +154,8 @@ export namespace vk {
 
                 m_image = sample_image(m_device, img_options);
 
-                // Staging buffer to transfer CPU-visible data to GPU-visible handles
+                // Staging buffer to transfer CPU-visible data to GPU-visible
+                // handles
                 buffer_parameters staging_options = {
                     .memory_mask = img_options.memory_mask,
                     .usage = buffer_usage::transfer_src_bit,

--- a/vulkan-cpp/types.cppm
+++ b/vulkan-cpp/types.cppm
@@ -1625,7 +1625,6 @@ export namespace vk {
 
         struct buffer_parameters {
             uint32_t memory_mask = 0;
-            memory_property property_flags;
             buffer_usage usage;
             memory_allocate_flags allocate_flags;
             VkSharingMode share_mode = VK_SHARING_MODE_EXCLUSIVE;

--- a/vulkan-cpp/types.cppm
+++ b/vulkan-cpp/types.cppm
@@ -1557,8 +1557,6 @@ export namespace vk {
         struct write_image {
             VkSampler sampler = nullptr;
             VkImageView view = nullptr;
-            // VkImageLayout
-            // image_layout=VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
             image_layout layout;
         };
         struct write_buffer {
@@ -1569,11 +1567,13 @@ export namespace vk {
 
         struct write_buffer_descriptor {
             uint32_t dst_binding;
+            uint32_t dst_array_element=0;
             std::span<const write_buffer> uniforms;
         };
 
         struct write_image_descriptor {
             uint32_t dst_binding;
+            uint32_t dst_array_element=0;
             std::span<const write_image> sample_images;
         };
 

--- a/vulkan-cpp/types.cppm
+++ b/vulkan-cpp/types.cppm
@@ -1567,13 +1567,13 @@ export namespace vk {
 
         struct write_buffer_descriptor {
             uint32_t dst_binding;
-            uint32_t dst_array_element=0;
+            uint32_t dst_array_element = 0;
             std::span<const write_buffer> uniforms;
         };
 
         struct write_image_descriptor {
             uint32_t dst_binding;
-            uint32_t dst_array_element=0;
+            uint32_t dst_array_element = 0;
             std::span<const write_image> sample_images;
         };
 

--- a/vulkan-cpp/vertex_buffer.cppm
+++ b/vulkan-cpp/vertex_buffer.cppm
@@ -35,9 +35,6 @@ export namespace vk {
                 // Staging buffer operations
                 buffer_parameters staging_buffer_params = {
                     .memory_mask = p_params.memory_mask,
-                    // .property_flags = static_cast<memory_property>(
-                    //   memory_property::host_visible_bit |
-                    //   memory_property::host_cached_bit),
                     .usage = buffer_usage::transfer_src_bit |
                              buffer_usage::storage_buffer_bit,
                     .debug_name = p_params.debug_name,
@@ -106,9 +103,6 @@ export namespace vk {
                 uint32_t usage = transfer | storage;
                 buffer_parameters staging_buffer_params = {
                     .memory_mask = p_params.memory_mask,
-                    // .property_flags = static_cast<memory_property>(
-                    //   memory_property::host_visible_bit |
-                    //   memory_property::host_cached_bit),
                     .usage = buffer_usage::transfer_src_bit |
                              buffer_usage::storage_buffer_bit,
                     .debug_name = p_params.debug_name,

--- a/vulkan-cpp/vertex_buffer.cppm
+++ b/vulkan-cpp/vertex_buffer.cppm
@@ -35,9 +35,9 @@ export namespace vk {
                 // Staging buffer operations
                 buffer_parameters staging_buffer_params = {
                     .memory_mask = p_params.memory_mask,
-                    .property_flags = static_cast<memory_property>(
-                      memory_property::host_visible_bit |
-                      memory_property::host_cached_bit),
+                    // .property_flags = static_cast<memory_property>(
+                    //   memory_property::host_visible_bit |
+                    //   memory_property::host_cached_bit),
                     .usage = buffer_usage::transfer_src_bit |
                              buffer_usage::storage_buffer_bit,
                     .debug_name = p_params.debug_name,
@@ -106,9 +106,9 @@ export namespace vk {
                 uint32_t usage = transfer | storage;
                 buffer_parameters staging_buffer_params = {
                     .memory_mask = p_params.memory_mask,
-                    .property_flags = static_cast<memory_property>(
-                      memory_property::host_visible_bit |
-                      memory_property::host_cached_bit),
+                    // .property_flags = static_cast<memory_property>(
+                    //   memory_property::host_visible_bit |
+                    //   memory_property::host_cached_bit),
                     .usage = buffer_usage::transfer_src_bit |
                              buffer_usage::storage_buffer_bit,
                     .debug_name = p_params.debug_name,


### PR DESCRIPTION
This PR exposes to additional parameters for descriptor set resources and include some minor fixes.

## Changelogs
- Added `dst_array_element` to `vk::write_image_descriptor` and `vk::write_buffer_descriptor` for descriptors.
- Remove unused `property_flags` parameter from `vk::buffer_parameters`.