### PR TITLE
Fix: Out-of-boounds memory type index allocation for discrete GPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ jobs:
     uses: engine3d-dev/ci/.github/workflows/windows.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit
 
   linux:
     uses: engine3d-dev/ci/.github/workflows/linux.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit
 
   mac:
     uses: engine3d-dev/ci/.github/workflows/mac.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,19 @@ jobs:
     uses: engine3d-dev/ci/.github/workflows/deploy_windows.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit
 
   linux:
     uses: engine3d-dev/ci/.github/workflows/deploy_linux.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit
 
   mac:
     uses: engine3d-dev/ci/.github/workflows/deploy_mac.yml@main
     with:
       package_name: "vulkan-cpp"
-      version: "6.1"
+      version: "6.2"
     secrets: inherit

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.2.0"
 
 class VulkanCppRecipe(ConanFile):
     name = "vulkan-cpp"
-    version = "6.1"
+    version = "6.2"
     license = "Apache-2.0"
     url = "https://github.com/engine3d-dev/vulkan-cpp"
     homepage = "https://github.com/engine3d-dev/vulkan-cpp"

--- a/demos/1-instance/conanfile.py
+++ b/demos/1-instance/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/10-textures/conanfile.py
+++ b/demos/10-textures/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/11-depth-buffering/conanfile.py
+++ b/demos/11-depth-buffering/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/12-loading-models/conanfile.py
+++ b/demos/12-loading-models/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/13-skybox/conanfile.py
+++ b/demos/13-skybox/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/14-imgui/conanfile.py
+++ b/demos/14-imgui/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/15-dynamic-rendering/conanfile.py
+++ b/demos/15-dynamic-rendering/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/16-descriptor-indexing/conanfile.py
+++ b/demos/16-descriptor-indexing/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/17-buffer-device-address/application.cpp
+++ b/demos/17-buffer-device-address/application.cpp
@@ -377,7 +377,7 @@ main() {
     // setting up physical device
 
     std::expected<vk::physical_device, VkResult> physical_device_expected =
-      api_instance.enumerate_physical_device(vk::physical_gpu::integrated);
+      api_instance.enumerate_physical_device(vk::physical_gpu::discrete);
     vk::physical_device physical_device = physical_device_expected.value();
 
     // setting up logical device

--- a/demos/17-buffer-device-address/conanfile.py
+++ b/demos/17-buffer-device-address/conanfile.py
@@ -20,7 +20,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/2-physical-device/conanfile.py
+++ b/demos/2-physical-device/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/3-logical-device/conanfile.py
+++ b/demos/3-logical-device/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/4-surface/conanfile.py
+++ b/demos/4-surface/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/5-swapchain/conanfile.py
+++ b/demos/5-swapchain/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/6-graphics-pipeline/conanfile.py
+++ b/demos/6-graphics-pipeline/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/7-vertex-buffer/conanfile.py
+++ b/demos/7-vertex-buffer/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/8-index-uniform-buffers/conanfile.py
+++ b/demos/8-index-uniform-buffers/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/demos/9-uniforms/conanfile.py
+++ b/demos/9-uniforms/conanfile.py
@@ -22,7 +22,7 @@ class Demo(ConanFile):
         self.requires("glm/1.0.1")
         self.requires("stb/cci.20230920")
         self.requires("tinyobjloader/2.0.0-rc10")
-        self.requires("vulkan-cpp/6.1")
+        self.requires("vulkan-cpp/6.2")
 
     def build(self):
         cmake = CMake(self)

--- a/vulkan-cpp/buffer.cppm
+++ b/vulkan-cpp/buffer.cppm
@@ -4,6 +4,7 @@ module;
 #include <span>
 #include <vector>
 #include <bit>
+#include <limits>
 
 export module vk:buffer;
 
@@ -63,8 +64,14 @@ export namespace vk {
                   m_device, m_handle, &memory_requirements);
                 uint32_t mapped_memory_requirements =
                   memory_requirements.memoryTypeBits & p_params.memory_mask;
-                uint32_t memory_index =
-                  std::countr_zero(mapped_memory_requirements);
+                  uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+                if (mapped_memory_requirements != 0) {
+                    memory_index = std::countr_zero(mapped_memory_requirements);
+                }
+                else {
+                    memory_index =
+                    std::countr_zero(memory_requirements.memoryTypeBits);
+                }
 
                 VkMemoryAllocateInfo memory_alloc_info = {
                     .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,

--- a/vulkan-cpp/buffer.cppm
+++ b/vulkan-cpp/buffer.cppm
@@ -64,13 +64,13 @@ export namespace vk {
                   m_device, m_handle, &memory_requirements);
                 uint32_t mapped_memory_requirements =
                   memory_requirements.memoryTypeBits & p_params.memory_mask;
-                  uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+                uint32_t memory_index = std::numeric_limits<uint32_t>::max();
                 if (mapped_memory_requirements != 0) {
                     memory_index = std::countr_zero(mapped_memory_requirements);
                 }
                 else {
                     memory_index =
-                    std::countr_zero(memory_requirements.memoryTypeBits);
+                      std::countr_zero(memory_requirements.memoryTypeBits);
                 }
 
                 VkMemoryAllocateInfo memory_alloc_info = {

--- a/vulkan-cpp/buffer32.cppm
+++ b/vulkan-cpp/buffer32.cppm
@@ -58,7 +58,7 @@ export namespace vk {
                 }
                 else {
                     memory_index =
-                    std::countr_zero(memory_requirements.memoryTypeBits);
+                      std::countr_zero(memory_requirements.memoryTypeBits);
                 }
 
                 VkMemoryAllocateInfo memory_alloc_info = {

--- a/vulkan-cpp/buffer32.cppm
+++ b/vulkan-cpp/buffer32.cppm
@@ -5,6 +5,7 @@ module;
 #include <array>
 #include <cstring>
 #include <bit>
+#include <limits>
 
 export module vk:buffer32;
 
@@ -50,8 +51,15 @@ export namespace vk {
                   m_device, m_handle, &memory_requirements);
                 uint32_t mapped_memory_requirements =
                   memory_requirements.memoryTypeBits & p_params.memory_mask;
-                uint32_t memory_index =
-                  std::countr_zero(mapped_memory_requirements);
+
+                uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+                if (mapped_memory_requirements != 0) {
+                    memory_index = std::countr_zero(mapped_memory_requirements);
+                }
+                else {
+                    memory_index =
+                    std::countr_zero(memory_requirements.memoryTypeBits);
+                }
 
                 VkMemoryAllocateInfo memory_alloc_info = {
                     .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,

--- a/vulkan-cpp/dyn/buffer.cppm
+++ b/vulkan-cpp/dyn/buffer.cppm
@@ -1,9 +1,10 @@
 module;
 
-#include <vulkan/vulkan.h>
-#include <vector>
-#include <span>
 #include <bit>
+#include <span>
+#include <vector>
+#include <vulkan/vulkan.h>
+#include <limits>
 
 export module vk:buffer_device_address;
 
@@ -56,8 +57,15 @@ export namespace vk::dyn {
               m_device, m_handle, &memory_requirements);
             uint32_t mapped_memory_requirements =
               memory_requirements.memoryTypeBits & p_params.memory_mask;
-            uint32_t memory_index =
-              std::countr_zero(mapped_memory_requirements);
+
+            uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+            if (mapped_memory_requirements != 0) {
+                memory_index = std::countr_zero(mapped_memory_requirements);
+            }
+            else {
+                memory_index =
+                  std::countr_zero(memory_requirements.memoryTypeBits);
+            }
 
             // Required to be set for buffer device addresses
             VkMemoryAllocateInfo memory_alloc_info = {
@@ -83,26 +91,30 @@ export namespace vk::dyn {
             for (uint32_t i = 0; i < image_copies.size(); i++) {
                 const buffer_image_copy image_copy = p_copies[i];
                 image_copies[i] = {
-                    .bufferOffset = image_copy.offset,
-                    .bufferRowLength = image_copy.row_length,
-                    .bufferImageHeight = image_copy.image_height,
-                    .imageSubresource = {
-                        .aspectMask = static_cast<VkImageAspectFlags>(image_copy.aspect_mask),
-                        .mipLevel = image_copy.mip_level,
-                        .baseArrayLayer = image_copy.base_array_layer,
-                        .layerCount = image_copy.layer_count,
-                    },
-                    .imageOffset = {
-                        static_cast<int32_t>(image_copy.image_offset.width),
-                        static_cast<int32_t>(image_copy.image_offset.height),
-                        static_cast<int32_t>(image_copy.image_offset.depth),
-                    },
-                    .imageExtent = {
-                        image_copy.image_extent.width,
-                        image_copy.image_extent.height,
-                        image_copy.image_extent.depth,
-                    },
-                };
+          .bufferOffset = image_copy.offset,
+          .bufferRowLength = image_copy.row_length,
+          .bufferImageHeight = image_copy.image_height,
+          .imageSubresource =
+              {
+                  .aspectMask =
+                      static_cast<VkImageAspectFlags>(image_copy.aspect_mask),
+                  .mipLevel = image_copy.mip_level,
+                  .baseArrayLayer = image_copy.base_array_layer,
+                  .layerCount = image_copy.layer_count,
+              },
+          .imageOffset =
+              {
+                  static_cast<int32_t>(image_copy.image_offset.width),
+                  static_cast<int32_t>(image_copy.image_offset.height),
+                  static_cast<int32_t>(image_copy.image_offset.depth),
+              },
+          .imageExtent =
+              {
+                  image_copy.image_extent.width,
+                  image_copy.image_extent.height,
+                  image_copy.image_extent.depth,
+              },
+      };
             }
 
             vkCmdCopyBufferToImage(p_command,
@@ -171,4 +183,4 @@ export namespace vk::dyn {
         VkBuffer m_handle = nullptr;
         VkDeviceMemory m_device_memory;
     };
-};
+}; // namespace vk::dyn

--- a/vulkan-cpp/sample_image.cppm
+++ b/vulkan-cpp/sample_image.cppm
@@ -4,6 +4,7 @@ module;
 #include <span>
 #include <vector>
 #include <bit>
+#include <limits>
 
 export module vk:sample_image;
 
@@ -78,8 +79,14 @@ export namespace vk {
                   p_image_params.memory_mask;
 
                 // Retrieving the next available bits that have been mapped
-                uint32_t memory_index =
-                  std::countr_zero(mapped_memory_requirements);
+                uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+                if (mapped_memory_requirements != 0) {
+                    memory_index = std::countr_zero(mapped_memory_requirements);
+                }
+                else {
+                    memory_index =
+                    std::countr_zero(memory_requirements.memoryTypeBits);
+                }
 
                 // 4. Allocate info
                 VkMemoryAllocateInfo memory_alloc_info = {

--- a/vulkan-cpp/sample_image.cppm
+++ b/vulkan-cpp/sample_image.cppm
@@ -85,7 +85,7 @@ export namespace vk {
                 }
                 else {
                     memory_index =
-                    std::countr_zero(memory_requirements.memoryTypeBits);
+                      std::countr_zero(memory_requirements.memoryTypeBits);
                 }
 
                 // 4. Allocate info


### PR DESCRIPTION
## Issue Overview
The way vulkan-cpp allows for specifying for memory allocations is managed by the `vk::physical_device` to retrieve the bit masks of the available memory properties. The physical device to determine the capabilities themask to determine where resources should live in.

On `integrated` physical device types, these masks overlap. Whereas on discrete physical device types have a varied different memory type and heap configurations.

Which caused cases where the buffers memory requirements and the requested device property mask had no common bits.
- Resulting in the bitmasking to be 0.
- Passing 0 to `std::countr_zero` caused to return 32.
- Passing an invalid index type of `32` to the Vulkan `vkAllocateMemory` APIs.

## Fixes

To fix this, I added a fallback to handle such edge case for specifying `std::countr_zero` and passing in the memoryTypeBits provided by the buffer memory requirements.

The fallback will evaluate the supported memory indexes and choose the first bit that represents the available supported memory index for allocation for the specific device type.